### PR TITLE
backend:compression-in-redis-stream-object

### DIFF
--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -69,7 +69,8 @@ library
     EulerHS.Runtime
     EulerHS.Types
     EulerHS.SqlDB.Language
-    EulerHS.KVConnector.DBSync 
+    EulerHS.KVConnector.DBSync
+    EulerHS.KVConnector.Compression 
     EulerHS.KVConnector.Encoding
     EulerHS.KVConnector.Flow
     EulerHS.KVConnector.Metrics
@@ -113,6 +114,7 @@ library
     , QuickCheck
     , aeson
     , aeson-pretty
+    , zstd
     , base64-bytestring
     , beam-core             
     , beam-mysql            
@@ -230,6 +232,7 @@ if flag(enable-tests)
     build-depends:
       , aeson
       , aeson-pretty
+      , zstd
       , async
       , beam-core
       , beam-sqlite

--- a/flake.lock
+++ b/flake.lock
@@ -495,16 +495,16 @@
     "hedis": {
       "flake": false,
       "locked": {
-        "lastModified": 1715851947,
-        "narHash": "sha256-R1ykEbhpCXDJ3N309PccIIhAZysKWPS305ECZ7EoF6g=",
+        "lastModified": 1730967537,
+        "narHash": "sha256-RDF/G/ptWazyFxCQOv+fTTQVV4hzDxTV630rnmhH3i4=",
         "ref": "refs/heads/master",
-        "rev": "b04adb840be7119f391afbf009cbbc02135175c0",
-        "revCount": 736,
+        "rev": "5547eb306006243f57d54e8ebb5225a055d40e73",
+        "revCount": 741,
         "type": "git",
         "url": "https://github.com/juspay/hedis"
       },
       "original": {
-        "rev": "b04adb840be7119f391afbf009cbbc02135175c0",
+        "rev": "5547eb306006243f57d54e8ebb5225a055d40e73",
         "type": "git",
         "url": "https://github.com/juspay/hedis"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     sequelize.inputs.haskell-flake.follows = "haskell-flake";
     sequelize.inputs.flake-parts.follows = "flake-parts";
 
-    hedis.url = "git+https://github.com/juspay/hedis?rev=b04adb840be7119f391afbf009cbbc02135175c0";
+    hedis.url = "git+https://github.com/juspay/hedis?rev=5547eb306006243f57d54e8ebb5225a055d40e73";
     hedis.flake = false;
 
     servant-mock.url = "github:arjunkathuria/servant-mock?rev=17e90cb831820a30b3215d4f164cf8268607891e";

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,10 @@
       perSystem = { self', pkgs, lib, config, ... }: {
         packages.default = self'.packages.euler-hs;
         haskellProjects.default = {
-          devShell.tools = _: lib.mkForce { haskell-language-server = null; };
+          devShell.tools = _: lib.mkForce {
+          haskell-language-server = null;
+          ormolu = pkgs.haskellPackages.ormolu;
+        };
           projectFlakeName = "euler-hs";
           imports = [
             inputs.euler-events-hs.haskellFlakeProjectModules.output

--- a/src/EulerHS/KVConnector/Compression.hs
+++ b/src/EulerHS/KVConnector/Compression.hs
@@ -8,26 +8,40 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import qualified Data.ByteString.Char8 as CBS
 import qualified EulerHS.Language as L
 import EulerHS.Prelude
 import EulerHS.Types
+import qualified Juspay.Extra.Config as Conf
+
+isCompressionAllowed :: Bool
+isCompressionAllowed = fromMaybe False $ readMaybe =<< Conf.lookupEnvT @String "COMPRESSION_ALLOWED"
 
 -- Data structure to hold compression parameters
 data CompressionParams = CompressionParams
   { compressionLevel :: Int,
-    threshold :: Int
+    sizeThreshold :: Int
   }
   deriving stock (Generic, Typeable, Show, Eq)
   deriving anyclass (ToJSON, FromJSON)
 
--- Key used to fetch CompressionParams
-data CompressionParamsKey = CompressionParamsKey
+defaultCompressionParams :: CompressionParams
+defaultCompressionParams = CompressionParams 2 256
+
+-- Hashmap to hold compression tables
+data CompressionTables = CompressionTables (HM.HashMap T.Text CompressionParams)
   deriving stock (Generic, Typeable, Show, Eq)
   deriving anyclass (ToJSON, FromJSON)
 
-instance OptionEntity CompressionParamsKey CompressionParams
+-- Key used to fetch CompressionParams
+data CompressionTableParams = CompressionTableParams
+  deriving stock (Generic, Typeable, Show, Eq)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance OptionEntity CompressionTableParams CompressionTables
 
 -- Error type for compression failures
 data CompressionError = CompressionError String BS.ByteString
@@ -38,8 +52,13 @@ data DecompressionError = DecompressionError String BS.ByteString
   deriving (Show)
 
 -- | Retrieve compression parameters, using a default if not found
-getCompressionParams :: (L.MonadFlow m) => m CompressionParams
-getCompressionParams = fromMaybe (CompressionParams 2 512) <$> L.getOption CompressionParamsKey
+getCompressionParamsForTable :: (L.MonadFlow m) => Maybe T.Text -> m CompressionParams
+getCompressionParamsForTable Nothing = pure defaultCompressionParams
+getCompressionParamsForTable (Just tble) = do
+  compressionTables <- L.getOption CompressionTableParams
+  case compressionTables of
+    Just (CompressionTables tables) -> pure $ HM.lookupDefault defaultCompressionParams tble tables
+    Nothing -> pure defaultCompressionParams
 
 -- | Compress the input ByteString
 compress :: Maybe Int -> BS.ByteString -> IO (Either CompressionError BS.ByteString)
@@ -50,13 +69,18 @@ compress compressionLevel' input = do
     Left err -> pure $ Left (CompressionError ("Compression error: " <> show err) input)
     Right output -> pure $ Right output
 
-compressWithoutError :: Maybe Int -> BS.ByteString -> IO BS.ByteString
-compressWithoutError compressionLevel' input = do
-  let compressionLevel'' = fromMaybe 2 compressionLevel'
-  result <- try (pure $ Zstd.compress compressionLevel'' input) :: IO (Either SomeException BS.ByteString)
-  case result of
-    Left _ -> pure input
-    Right output -> pure output
+compressWithoutError :: (L.MonadFlow m) => Maybe Text -> BS.ByteString -> m BS.ByteString
+compressWithoutError table input = do
+  compressionParams <- getCompressionParamsForTable table
+  if BS.length input < sizeThreshold compressionParams
+    then pure input
+    else do
+      result <- L.runIO $ compress (Just compressionParams.compressionLevel) input
+      case result of
+        Left err -> do
+          L.logError @T.Text "Error while compressing object: " $ T.pack $ show err
+          pure input
+        Right output -> pure output
 
 -- | Decompress the input ByteString
 decompress :: BS.ByteString -> IO (Either DecompressionError BS.ByteString)
@@ -81,11 +105,11 @@ decompressWithoutError input = do
 -- Compression and Decompression of Objects
 -------------------------------------------------
 
-compressObject :: (ToJSON a, L.MonadFlow m) => a -> m T.Text
-compressObject obj = do
-  compressionParams <- getCompressionParams
+compressObject :: (ToJSON a, L.MonadFlow m) => Maybe Text -> a -> m T.Text
+compressObject tble obj = do
+  compressionParams <- getCompressionParamsForTable tble
   let strictByteString = BL.toStrict (A.encode obj)
-  if BS.length strictByteString < threshold compressionParams
+  if BS.length strictByteString < sizeThreshold compressionParams
     then return (TE.decodeUtf8 strictByteString)
     else do
       compressResult <- L.runIO $ compress (Just $ compressionLevel compressionParams) strictByteString
@@ -113,46 +137,23 @@ decompressObject compressedObj = do
 -- Compression and Decompression with IO monad
 -------------------------------------------------
 
-compressObjectIO :: (ToJSON a) => a -> IO T.Text
-compressObjectIO obj = do
-  let encodedObj = A.encode obj
-  if (length encodedObj) < compressionThreshold
-    then return (TE.decodeUtf8 $ BL.toStrict encodedObj)
-    else do
-      let strictByteString = BL.toStrict encodedObj
-      compressResult <- compress (Just 1) strictByteString
-      case compressResult of
-        Left (CompressionError err _) -> do
-          print $ "Error while compressing object: " ++ err
-          return (TE.decodeUtf8 strictByteString)
-        Right compressed -> return (TE.decodeUtf8 $ B64.encode compressed)
-
--- | Decompress and decode from Base64
-decompressObjectIO :: (FromJSON a) => T.Text -> IO (Maybe a)
-decompressObjectIO compressedObj = do
-  let decodedResult = B64.decode (TE.encodeUtf8 compressedObj) -- Decode Base64
-  case decodedResult of
-    Left err -> do
-      print $ "Error while decoding Base64: " ++ err
-      return Nothing -- Return Nothing if decoding fails
-    Right strictByteString -> do
-      decompressResult <- decompress strictByteString -- Decompress the object
-      case decompressResult of
-        Left (DecompressionError err _) -> do
-          print $ "Error while decompressing object: " ++ err
-          return $ A.decode (BL.fromStrict strictByteString) -- Return original if decompression fails
-        Right decompressed -> return $ A.decode (BL.fromStrict decompressed)
+compressIO :: Maybe Int -> BS.ByteString -> IO ()
+compressIO compressionLevel' input = do
+  result <- compress compressionLevel' input
+  case result of
+    Left (CompressionError err _) -> 
+      putStrLn $ "Error while compressing object: " ++ err
+    Right compressed -> do 
+      -- Convert the Base64-encoded ByteString into a String and print
+      let encodedString = CBS.unpack (B64.encode compressed)
+      putStrLn $ "Compressed Object: " ++ encodedString
 
 decompressIO :: String -> IO ()
 decompressIO compressedObj = do
-  let decodedResult = B64.decode (TE.encodeUtf8 $ T.pack compressedObj) -- Decode Base64
-  case decodedResult of
-    Left err -> print $ "Error while decoding Base64: " ++ err
-    Right strictByteString -> do
-      decompressResult <- decompress strictByteString -- Decompress the object
-      case decompressResult of
-        Left (DecompressionError err _) -> print $ "Error while decompressing object: " ++ err
-        Right decompressed -> print decompressed
+  let strictByteString = CBS.pack compressedObj -- Correctly handles String to ByteString
+  decompressResult <- decompressWithoutError (B64.decodeLenient strictByteString)
+  print decompressResult
+
 
 -------------------------------------------------
 -- Test Cases
@@ -192,11 +193,41 @@ person =
             city = "Metropolis",
             postalCode = "12345"
           },
-      friends = replicate 3 (Person "Friend" 30 (Address "123 Friend St" "Friend City" "12345") [])
+      friends = replicate 7 (Person "Friend" 30 (Address "123 Friend St" "Friend City" "12345") [])
     }
 
 compressionThreshold :: Int
 compressionThreshold = 512
+
+compressObjectIO :: (ToJSON a) => a -> IO T.Text
+compressObjectIO obj = do
+  let encodedObj = A.encode obj
+  if (length encodedObj) < compressionThreshold
+    then return (TE.decodeUtf8 $ BL.toStrict encodedObj)
+    else do
+      let strictByteString = BL.toStrict encodedObj
+      compressResult <- compress (Just 1) strictByteString
+      case compressResult of
+        Left (CompressionError err _) -> do
+          print $ "Error while compressing object: " ++ err
+          return (TE.decodeUtf8 strictByteString)
+        Right compressed -> return (TE.decodeUtf8 $ B64.encode compressed)
+
+-- | Decompress and decode from Base64
+decompressObjectIO :: (FromJSON a) => T.Text -> IO (Maybe a)
+decompressObjectIO compressedObj = do
+  let decodedResult = B64.decode (TE.encodeUtf8 compressedObj) -- Decode Base64
+  case decodedResult of
+    Left err -> do
+      print $ "Error while decoding Base64: " ++ err
+      return Nothing -- Return Nothing if decoding fails
+    Right strictByteString -> do
+      decompressResult <- decompress strictByteString -- Decompress the object
+      case decompressResult of
+        Left (DecompressionError err _) -> do
+          print $ "Error while decompressing object: " ++ err
+          return $ A.decode (BL.fromStrict strictByteString) -- Return original if decompression fails
+        Right decompressed -> return $ A.decode (BL.fromStrict decompressed)
 
 -- | Test compress and decompress function
 testCompressDecompress :: IO ()
@@ -204,7 +235,7 @@ testCompressDecompress = do
   when (length (A.encode person) > compressionThreshold) $ do
     compressed <- compressObjectIO person -- Compress the object
     print $ "Length of compressed object: " ++ show (T.length compressed)
-    -- print $ "Compressed Object: " ++ T.unpack compressed
+    print $ "Compressed Object: " ++ T.unpack compressed
     decompressed <- decompressObjectIO compressed -- Decompress the object
     case decompressed of
       Just person' -> do

--- a/src/EulerHS/KVConnector/Compression.hs
+++ b/src/EulerHS/KVConnector/Compression.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module EulerHS.KVConnector.Compression where
+
+import qualified Codec.Compression.Zstd as Zstd
+import qualified Data.Aeson as A
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified EulerHS.Language as L
+import EulerHS.Prelude
+import EulerHS.Types
+
+-- Data structure to hold compression parameters
+data CompressionParams = CompressionParams
+  { compressionLevel :: Int,
+    threshold :: Int
+  }
+  deriving stock (Generic, Typeable, Show, Eq)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- Key used to fetch CompressionParams
+data CompressionParamsKey = CompressionParamsKey
+  deriving stock (Generic, Typeable, Show, Eq)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance OptionEntity CompressionParamsKey CompressionParams
+
+-- Error type for compression failures
+data CompressionError = CompressionError String BS.ByteString
+  deriving (Show)
+
+-- Error type for decompression failures
+data DecompressionError = DecompressionError String BS.ByteString
+  deriving (Show)
+
+-- | Retrieve compression parameters, using a default if not found
+getCompressionParams :: (L.MonadFlow m) => m CompressionParams
+getCompressionParams = fromMaybe (CompressionParams 2 512) <$> L.getOption CompressionParamsKey
+
+-- | Compress the input ByteString
+compress :: Maybe Int -> BS.ByteString -> IO (Either CompressionError BS.ByteString)
+compress compressionLevel' input = do
+  let compressionLevel'' = fromMaybe 2 compressionLevel'
+  result <- try (pure $ Zstd.compress compressionLevel'' input) :: IO (Either SomeException BS.ByteString)
+  case result of
+    Left err -> pure $ Left (CompressionError ("Compression error: " <> show err) input)
+    Right output -> pure $ Right output
+
+-- | Decompress the input ByteString
+decompress :: BS.ByteString -> IO (Either DecompressionError BS.ByteString)
+decompress input = do
+  result <- try (pure $ Zstd.decompress input) :: IO (Either SomeException Zstd.Decompress)
+  case result of
+    Left _ -> pure $ Right input
+    Right Zstd.Skip -> pure $ Right input
+    Right (Zstd.Error err) -> pure $ Left (DecompressionError ("Decompression error: " <> err) input)
+    Right (Zstd.Decompress output) -> pure $ Right output
+
+-------------------------------------------------
+-- Compression and Decompression of Objects
+-------------------------------------------------
+
+compressObject :: (ToJSON a, L.MonadFlow m) => a -> m T.Text
+compressObject obj = do
+  compressionParams <- getCompressionParams
+  let strictByteString = BL.toStrict (A.encode obj)
+  if BS.length strictByteString < threshold compressionParams
+    then return (TE.decodeUtf8 strictByteString)
+    else do
+      compressResult <- L.runIO $ compress (Just $ compressionLevel compressionParams) strictByteString
+      case compressResult of
+        Left (CompressionError err _) -> do
+          L.logError @T.Text "Error while compressing object: " $ T.pack err
+          return $ TE.decodeUtf8 strictByteString
+        Right compressed -> return $ TE.decodeUtf8 $ B64.encode compressed
+
+decompressObject :: (FromJSON a, L.MonadFlow m) => T.Text -> m (Maybe a)
+decompressObject compressedObj = do
+  case B64.decode (TE.encodeUtf8 compressedObj) of
+    Left err -> do
+      L.logError @T.Text "Error while decoding Base64: " $ T.pack err
+      return Nothing
+    Right strictByteString -> do
+      decompressResult <- L.runIO $ decompress strictByteString
+      case decompressResult of
+        Left (DecompressionError err _) -> do
+          L.logError @T.Text "Error while decompressing object: " $ T.pack err
+          return $ A.decode (BL.fromStrict strictByteString)
+        Right decompressed -> return $ A.decode (BL.fromStrict decompressed)
+
+-------------------------------------------------
+-- Compression and Decompression with IO monad
+-------------------------------------------------
+
+compressObjectIO :: (ToJSON a) => a -> IO T.Text
+compressObjectIO obj = do
+  let encodedObj = A.encode obj
+  if (length encodedObj) < compressionThreshold
+    then return (TE.decodeUtf8 $ BL.toStrict encodedObj)
+    else do
+      let strictByteString = BL.toStrict encodedObj
+      compressResult <- compress (Just 1) strictByteString
+      case compressResult of
+        Left (CompressionError err _) -> do
+          print $ "Error while compressing object: " ++ err
+          return (TE.decodeUtf8 strictByteString)
+        Right compressed -> return (TE.decodeUtf8 $ B64.encode compressed)
+
+-- | Decompress and decode from Base64
+decompressObjectIO :: (FromJSON a) => T.Text -> IO (Maybe a)
+decompressObjectIO compressedObj = do
+  let decodedResult = B64.decode (TE.encodeUtf8 compressedObj) -- Decode Base64
+  case decodedResult of
+    Left err -> do
+      print $ "Error while decoding Base64: " ++ err
+      return Nothing -- Return Nothing if decoding fails
+    Right strictByteString -> do
+      decompressResult <- decompress strictByteString -- Decompress the object
+      case decompressResult of
+        Left (DecompressionError err _) -> do
+          print $ "Error while decompressing object: " ++ err
+          return $ A.decode (BL.fromStrict strictByteString) -- Return original if decompression fails
+        Right decompressed -> return $ A.decode (BL.fromStrict decompressed)
+
+-------------------------------------------------
+-- Test Cases
+-------------------------------------------------
+
+data Address = Address
+  { street :: String,
+    city :: String,
+    postalCode :: String
+  }
+  deriving (Show, Generic)
+
+data Person = Person
+  { name :: String,
+    age :: Int,
+    address :: Address,
+    friends :: [Person] -- Recursive structure for a large list of friends
+  }
+  deriving (Show, Generic)
+
+instance ToJSON Address
+
+instance FromJSON Address
+
+instance ToJSON Person
+
+instance FromJSON Person
+
+person :: Person
+person =
+  Person
+    { name = "John Doe",
+      age = 45,
+      address =
+        Address
+          { street = "123 Main St",
+            city = "Metropolis",
+            postalCode = "12345"
+          },
+      friends = replicate 3 (Person "Friend" 30 (Address "123 Friend St" "Friend City" "12345") [])
+    }
+
+compressionThreshold :: Int
+compressionThreshold = 512
+
+-- | Test compress and decompress function
+testCompressDecompress :: IO ()
+testCompressDecompress = do
+  when (length (A.encode person) > compressionThreshold) $ do
+    compressed <- compressObjectIO person -- Compress the object
+    print $ "Length of compressed object: " ++ show (T.length compressed)
+    -- print $ "Compressed Object: " ++ T.unpack compressed
+    decompressed <- decompressObjectIO compressed -- Decompress the object
+    case decompressed of
+      Just person' -> do
+        -- print $ "Decompressed Object: " ++ show (person' :: Person)
+        print $ "Length of decompressed object: " ++ show (length $ BL.toStrict $ A.encode (person' :: Person))
+      Nothing -> print ("Failed to decompress" :: T.Text)
+  return ()


### PR DESCRIPTION
### PR Description:

**Title:** Add Compression and Decompression Utilities for KVConnector

**Summary:**  
This PR adds Zstandard-based compression and decompression functions to the KVConnector module. It includes handling for JSON objects, with Base64 encoding and configurable compression parameters. Error handling is implemented for both compression and decompression processes. Test cases are provided for validation.

**Key Changes:**
- Added `CompressionParams` for configurable compression level and size threshold.
- Implemented `compressObject` and `decompressObject` for compressing and decompressing JSON objects.
- IO-based `compressObjectIO` and `decompressObjectIO` functions for non-monadic use cases.
- Error logging and handling for compression and decompression failures.
- Currently implemented for redis-stream entry for create objects.

**Testing:**  
Includes test cases for compressing and decompressing sample objects.