### PR TITLE
backend: refactor sharding logic to accept shard modifier as parameter

### DIFF
--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -146,7 +146,7 @@ createKV meshCfg value = do
   case autoIncIdRes of
     Right val -> do
       let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix val
-          shard = getShardedHashTag meshCfg.shardModValue pKeyText
+          shard = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
           pKey = fromString . T.unpack $ pKeyText <> shard
       time <- fromIntegral <$> L.getCurrentDateInMillis
 
@@ -186,7 +186,7 @@ createInRedis :: forall (table :: (Type -> Type) -> Type) m.
   m (MeshResult (table Identity))
 createInRedis meshCfg val = do
   let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix val
-      shard = getShardedHashTag meshCfg.shardModValue pKeyText
+      shard = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
       pKey = fromString . T.unpack $ pKeyText <> shard
   revMappingRes <- mapM (\secIdx -> do
     let sKey = fromString . T.unpack $ secIdx
@@ -451,7 +451,7 @@ updateObjectRedis meshCfg updVals setClauses addPrimaryKeyToWhereClause whereCla
     Right updatedModel -> do
       time <- fromIntegral <$> L.getCurrentDateInMillis
       let pKeyText  = getLookupKeyByPKey meshCfg.redisKeyPrefix obj
-          shard     = getShardedHashTag meshCfg.shardModValue pKeyText
+          shard     = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
           pKey      = fromString . T.unpack $ pKeyText <> shard
           updateCmd = if addPrimaryKeyToWhereClause
                         then getDbUpdateCommandJsonWithPrimaryKey (getTableName @(table Identity)) setClauses obj whereClause
@@ -483,7 +483,7 @@ updateObjectRedis meshCfg updVals setClauses addPrimaryKeyToWhereClause whereCla
     modifySKeysRedis :: [[(Text, Text)]] -> table Identity -> m (MeshResult (table Identity)) -- TODO: Optimise this logic
     modifySKeysRedis olderSkeys table = do
       let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix table
-          shard = getShardedHashTag meshCfg.shardModValue pKeyText
+          shard = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
           pKey = fromString . T.unpack $ pKeyText <> shard
       let tName = tableName @(table Identity)
           updValsMap = HM.fromList (map (\p -> (fst p, True)) updVals)
@@ -1139,7 +1139,7 @@ deleteObjectRedis :: forall table be beM m.
 deleteObjectRedis meshCfg addPrimaryKeyToWhereClause whereClause obj = do
   time <- fromIntegral <$> L.getCurrentDateInMillis
   let pKeyText  = getLookupKeyByPKey meshCfg.redisKeyPrefix obj
-      shard     = getShardedHashTag meshCfg.shardModValue pKeyText
+      shard     = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
       pKey      = fromString . T.unpack $ pKeyText <> shard
       deleteCmd = if addPrimaryKeyToWhereClause
                     then getDbDeleteCommandJsonWithPrimaryKey  (getTableName @(table Identity)) obj whereClause
@@ -1176,7 +1176,7 @@ reCacheDBRows :: forall table m.
 reCacheDBRows meshCfg dbRows = do
   reCacheRes <- mapM (\obj -> do
       let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix obj
-          shard = getShardedHashTag meshCfg.shardModValue pKeyText
+          shard = getShardedHashTag meshCfg.redisKeyPrefix meshCfg.shardModValue pKeyText
           pKey = fromString . T.unpack $ pKeyText <> shard
       res <- mapM (\secIdx -> do -- Recaching Skeys in redis
           let sKey = fromString . T.unpack $ secIdx

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -104,6 +104,7 @@ data MeshConfig = MeshConfig
   , redisTtl        :: L.KVDBDuration
   , kvHardKilled    :: Bool
   , shardModValue   :: Int
+  , redisKeyPrefix  :: Text
   }
   deriving (Generic, Eq, Show, A.ToJSON)
 

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -56,7 +56,7 @@ class TableMappings a where
 
 --------------- EXISTING DB MESH ---------------
 class MeshState a where
-  getShardedHashTag :: Int -> a -> Maybe Text
+  getShardedHashTag :: Text -> Int -> a -> Maybe Text
   getKVKey          :: a -> Maybe Text
   getKVDirtyKey     :: a -> Maybe Text
   isDBMeshEnabled   :: a -> Bool

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -56,7 +56,7 @@ class TableMappings a where
 
 --------------- EXISTING DB MESH ---------------
 class MeshState a where
-  getShardedHashTag :: a -> Maybe Text
+  getShardedHashTag :: Int -> a -> Maybe Text
   getKVKey          :: a -> Maybe Text
   getKVDirtyKey     :: a -> Maybe Text
   isDBMeshEnabled   :: a -> Bool
@@ -103,6 +103,7 @@ data MeshConfig = MeshConfig
   , kvRedis         :: Text
   , redisTtl        :: L.KVDBDuration
   , kvHardKilled    :: Bool
+  , shardModValue   :: Int
   }
   deriving (Generic, Eq, Show, A.ToJSON)
 

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -201,11 +201,7 @@ getDataFromPKeysRedis' :: forall table m. (
     L.MonadFlow m, MonadIO m) => MeshConfig -> Bool -> [ByteString] -> m (MeshResult ([table Identity], [table Identity]))
 getDataFromPKeysRedis' _ _ []  = pure $ Right ([], [])
 getDataFromPKeysRedis' meshCfg latencyLogging pKeys = do
-  -- Todo: to be removed
-  let pKeyWithoutPrefix = map (dropPrefix meshCfg.shardModValue) pKeys
-  -- here we will take all the keys which are true for drop prefix and skip the false ones
-  let pKeys' = map snd $ filter fst pKeyWithoutPrefix
-  let groupedKeys = groupKeysBySlot (pKeys <> pKeys')
+  let groupedKeys = groupKeysBySlot pKeys
   getDataFromPKeysHelper meshCfg groupedKeys latencyLogging
 
 getDataFromPKeysRedis :: forall table m. (
@@ -235,10 +231,7 @@ getDataFromPKeysRedis meshCfg latencyLogging (pKey : pKeys)  = do
           -- to handle the case where the key is not found in the redis and log the error
           L.logErrorT "getDataFromPKeysRedis" $ "Error while decoding: " <> show e
           return $ Right ([], [])
-    Right Nothing -> do
-      -- Todo: to be removed
-      let (hadPrefix, keyWithoutPrefix) = dropPrefix meshCfg.shardModValue pKey
-      bool (getDataFromPKeysRedis meshCfg latencyLogging pKeys) (getDataFromPKeysRedis meshCfg latencyLogging (keyWithoutPrefix : pKeys)) hadPrefix
+    Right Nothing -> getDataFromPKeysRedis meshCfg latencyLogging pKeys
     Left e -> return $ Left $ RedisError $ (show e <> " for key: " <> show (pKey : pKeys))
 
 ------------- KEY UTILS ------------------
@@ -538,16 +531,7 @@ getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = 
         Just False -> do
           res <- L.runKVDB meshCfg.kvRedis $ L.smembers (fromString $ T.unpack constructedKey)
           case res of
-            -- Todo: To be removed after redis key prefix is implemented
-            -- Right r -> pure $ Right $ Just r 
-            Right r -> do
-              let (hadPrefix, keyWithoutPrefix) = dropPrefix meshCfg.shardModValue (fromString $ T.unpack constructedKey)
-              if hadPrefix 
-                then do
-                  result' <- L.runKVDB meshCfg.kvRedis $ L.smembers keyWithoutPrefix
-                  let withoutPrefixResult = either (const []) id result'
-                  pure $ Right $ Just $ r ++ withoutPrefixResult
-                else pure $ Right $ Just r
+            Right r -> pure $ Right $ Just r
             Left e -> pure $ Left $ RedisError $ (show e <> " for key: " <> show constructedKey)
         _ -> pure $ Right Nothing
 

--- a/test/language/KV/InsertSpec.hs
+++ b/test/language/KV/InsertSpec.hs
@@ -48,7 +48,7 @@ spec = flowSpec $ do
         sc <- dummyServiceConfig
         withTableEntry sc $ (\serviceConfig _dbConf -> do
             let pKey = getPKeyWithShard 128 serviceConfig
-            let secKeys = getSecondaryLookupKeys serviceConfig
+            let secKeys = getSecondaryLookupKeys "" serviceConfig
             (valueFromPrimaryKey :: Maybe ServiceConfiguration) <- getValueFromPrimaryKey pKey
             valueFromSecondaryKeys <- (snd . partialHead) <$> getValueFromSecondaryKeys secKeys
             asserting $ valueFromPrimaryKey `shouldBe` valueFromSecondaryKeys

--- a/test/language/KV/InsertSpec.hs
+++ b/test/language/KV/InsertSpec.hs
@@ -47,7 +47,7 @@ spec = flowSpec $ do
     itFlow "Should add primary key and secondary keys to redis on insert command" $ do
         sc <- dummyServiceConfig
         withTableEntry sc $ (\serviceConfig _dbConf -> do
-            let pKey = getPKeyWithShard serviceConfig
+            let pKey = getPKeyWithShard 128 serviceConfig
             let secKeys = getSecondaryLookupKeys serviceConfig
             (valueFromPrimaryKey :: Maybe ServiceConfiguration) <- getValueFromPrimaryKey pKey
             valueFromSecondaryKeys <- (snd . partialHead) <$> getValueFromSecondaryKeys secKeys

--- a/test/language/KV/TestHelper.hs
+++ b/test/language/KV/TestHelper.hs
@@ -43,7 +43,7 @@ getValueFromSecondaryKeys secKeys = do
 deleteTableEntryValueFromKV :: (KVConnector (table Identity)) => table Identity -> L.Flow ()
 deleteTableEntryValueFromKV sc = do
   let pKey = getPKeyWithShard 128 sc
-  let secKeys = getSecondaryLookupKeys sc
+  let secKeys = getSecondaryLookupKeys "" sc
   void $ fromEitherToMaybe <$> (L.runKVDB kvRedis $ L.del ([encodeUtf8 pKey]))
   void $ fromEitherToMaybe <$> (L.runKVDB kvRedis $ L.del (encodeUtf8 <$> secKeys))
 

--- a/test/language/KV/TestHelper.hs
+++ b/test/language/KV/TestHelper.hs
@@ -42,7 +42,7 @@ getValueFromSecondaryKeys secKeys = do
 
 deleteTableEntryValueFromKV :: (KVConnector (table Identity)) => table Identity -> L.Flow ()
 deleteTableEntryValueFromKV sc = do
-  let pKey = getPKeyWithShard sc
+  let pKey = getPKeyWithShard 128 sc
   let secKeys = getSecondaryLookupKeys sc
   void $ fromEitherToMaybe <$> (L.runKVDB kvRedis $ L.del ([encodeUtf8 pKey]))
   void $ fromEitherToMaybe <$> (L.runKVDB kvRedis $ L.del (encodeUtf8 <$> secKeys))


### PR DESCRIPTION
**Enhancements to Sharding and Redis Key Management**

- Integrated `meshCfg.redisKeyPrefix` and `meshCfg.shardModValue` into key generation functions for consistent key structure.  
- Updated table-level sharding with shard ranges (`0` to `shardModValue`) based on `configs`.  
- New key format: `prefix_keyName{prefix_shard-range}` ensures distinct Redis hash slots for better distribution.  
- Refactored functions to support the new parameters and improve scalability.  