### PR TITLE
fix `tinylog` Flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1153,15 +1153,16 @@
       "locked": {
         "lastModified": 1669960992,
         "narHash": "sha256-o0WEbygbbfIYPonyY6ui1HcbaJcFdngjBhnjWbe65zs=",
+        "owner": "arjunkathuria",
+        "repo": "tinylog",
         "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
-        "revCount": 78,
-        "type": "git",
-        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+        "type": "gitlab"
       },
       "original": {
+        "owner": "arjunkathuria",
+        "repo": "tinylog",
         "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
-        "type": "git",
-        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+        "type": "gitlab"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     servant-mock.url = "github:arjunkathuria/servant-mock?rev=17e90cb831820a30b3215d4f164cf8268607891e";
     servant-mock.flake = false;
 
-    tinylog.url = "git+https://gitlab.com/arjunkathuria/tinylog.git?rev=08d3b6066cd2f883e183b7cd01809d1711092d33";
+    tinylog.url = "gitlab:arjunkathuria/tinylog/08d3b6066cd2f883e183b7cd01809d1711092d33";
     tinylog.flake = false;
   };
 


### PR DESCRIPTION
dependency probably moved to `develop` branch which broke the input: https://gitlab.com/arjunkathuria/tinylog

`"gitlab:..."` input is supported: https://github.com/NixOS/nix/blob/master/src/nix/flake.md#types