### PR TITLE
fix: merge primary and secondary Redis results for accurate data retr…

### DIFF
--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -1021,7 +1021,7 @@ findOneFromRedis meshCfg whereClause = do
                     Right secondaryRowsResPairList -> do
                       let (secondaryLiveListOfList, secondaryDeadListOfList) = unzip secondaryRowsResPairList
                       Metrics.incrementRedisCallMetric "REDIS_FIND_ONE_SECONDARY" modelName total_length (total_length > redisCallsSoftLimit ) (total_length > redisCallsHardLimit )
-                      return (Right (concat secondaryLiveListOfList, concat secondaryDeadListOfList), True)
+                      return (Right (concat secondaryLiveListOfList ++ primaryLiveRows, concat secondaryDeadListOfList ++ primaryDeadRows), True)
                     Left err -> return (Left err, True)
               else
                 return (Right (primaryLiveRows, primaryDeadRows), False)


### PR DESCRIPTION
…ieval

Updated the findOneFromRedis function to concatenate primary Redis results with secondary results, ensuring that all matching records are returned. This change addresses potential data inconsistencies when primary results are stale or non-matching, enhancing the reliability of cross-cloud lookups.