### PR TITLE
feat: schema-tolerant Postgres reads via to_jsonb fallback on 42703

### DIFF
--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -203,6 +203,7 @@ executable jsonb-live-test
   hs-source-dirs:   test-jsonb-live
   build-depends:
     , aeson
+    , async
     , base16-bytestring
     , beam-core
     , beam-postgres

--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -56,6 +56,7 @@ library
   import:          common-lang
   exposed-modules:
     EulerHS.CachedSqlDBQuery
+    EulerHS.JsonbFallback
     EulerHS.Extra.AltValidation
     EulerHS.Extra.Aeson
     EulerHS.Extra.Combinators
@@ -195,6 +196,23 @@ library
     , mtl
 
   hs-source-dirs:  src
+
+executable jsonb-live-test
+  import:           common-lang
+  main-is:          Main.hs
+  hs-source-dirs:   test-jsonb-live
+  build-depends:
+    , aeson
+    , beam-core
+    , beam-postgres
+    , euler-hs
+    , postgresql-simple
+    , sequelize
+    , text
+    , casing
+    , time
+    , vector
+  ghc-options:      -threaded
 
 flag enable-tests
   description: Enable building tests

--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -203,13 +203,15 @@ executable jsonb-live-test
   hs-source-dirs:   test-jsonb-live
   build-depends:
     , aeson
+    , base16-bytestring
     , beam-core
     , beam-postgres
+    , bytestring
+    , casing
     , euler-hs
     , postgresql-simple
     , sequelize
     , text
-    , casing
     , time
     , vector
   ghc-options:      -threaded

--- a/src/EulerHS/CachedSqlDBQuery.hs
+++ b/src/EulerHS/CachedSqlDBQuery.hs
@@ -38,6 +38,7 @@ import qualified Database.Beam.Sqlite as BS
 import qualified Database.Beam.Backend.SQL.BeamExtensions as BExt
 import           EulerHS.Extra.Language (getOrInitSqlConn, rGet, rSetB, rDel)
 import qualified EulerHS.Framework.Language as L
+import qualified EulerHS.JsonbFallback as JF
 import           EulerHS.Prelude
 import qualified EulerHS.SqlDB.Language as DB
 import           EulerHS.SqlDB.Types (BeamRunner, BeamRuntime, DBConfig(..),
@@ -300,7 +301,8 @@ findOne ::
     B.HasQBuilder be,
     ToJSON (table Identity),
     FromJSON (table Identity),
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Maybe Text ->
@@ -327,7 +329,8 @@ findAll ::
     B.HasQBuilder be,
     ToJSON (table Identity),
     FromJSON (table Identity),
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Maybe Text ->
@@ -519,38 +522,64 @@ countSql ::
 countSql dbConf whereClause = runQuery dbConf findQuery
   where findQuery = DB.countRows (sqlCount ! #where_ whereClause ! defaults)
 
+-- Postgres "42703 column does not exist".
+is42703DBError :: DBError -> Bool
+is42703DBError (DBError _ msg) =
+  T.isInfixOf "42703" msg
+    || (T.isInfixOf "does not exist" msg && T.isInfixOf "column" msg)
+
 findOneSql ::
+  forall be beM table m.
   ( HasCallStack,
     BeamRuntime be beM,
     BeamRunner beM,
     Model be table,
     B.HasQBuilder be,
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Where be table ->
   m (Either DBError (Maybe (table Identity)))
-findOneSql dbConf whereClause = runQuery dbConf findQuery
-  where findQuery = DB.findRow (sqlSelect ! #where_ whereClause ! defaults)
+findOneSql dbConf whereClause = do
+  result <- runQuery dbConf $ DB.findRow (sqlSelect ! #where_ whereClause ! defaults)
+  case result of
+    Right _ -> pure result
+    Left err
+      | is42703DBError err -> do
+          mFallback <- JF.tryJsonbFallback @beM @be @table dbConf whereClause (T.pack (show err))
+          pure $ case mFallback of
+            Just (r:_) -> Right (Just r)
+            _         -> result
+      | otherwise -> pure result
 
 findAllSql ::
+  forall be beM table m.
   ( HasCallStack,
     BeamRuntime be beM,
     BeamRunner beM,
     Model be table,
     B.HasQBuilder be,
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Where be table ->
   m (Either DBError [table Identity])
 findAllSql dbConf whereClause = do
-  let findQuery = DB.findRows (sqlSelect ! #where_ whereClause ! defaults)
   sqlConn <- getOrInitSqlConn dbConf
-  rows <- join <$> mapM (`L.runDB` findQuery) sqlConn
+  rows <- join <$> mapM (`L.runDB` DB.findRows (sqlSelect ! #where_ whereClause ! defaults)) sqlConn
   case rows of
     Right _ -> pure rows
-    Left err -> L.incrementDbMetric err dbConf *> pure rows
+    Left err -> do
+      L.incrementDbMetric err dbConf
+      if is42703DBError err
+        then do
+          mFallback <- JF.tryJsonbFallback @beM @be @table dbConf whereClause (T.pack (show err))
+          pure $ case mFallback of
+            Just rs -> Right rs
+            Nothing -> rows
+        else pure rows
 
 cacheWithKey :: (HasCallStack, ToJSON table, L.MonadFlow m) => Text -> table -> m ()
 cacheWithKey key row = do
@@ -638,7 +667,8 @@ deleteAllSqlMySQL ::
     BeamRunner beM,
     B.HasQBuilder be,
     Model be table,
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Where be table ->
@@ -660,7 +690,8 @@ deleteAllMySQL ::
     BeamRunner beM,
     B.HasQBuilder be,
     Model be table,
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   Where be table ->

--- a/src/EulerHS/CachedSqlDBQuery.hs
+++ b/src/EulerHS/CachedSqlDBQuery.hs
@@ -550,7 +550,8 @@ findOneSql dbConf whereClause = do
           mFallback <- JF.tryJsonbFallback @beM @be @table dbConf whereClause (T.pack (show err))
           pure $ case mFallback of
             Just (r:_) -> Right (Just r)
-            _         -> result
+            Just []    -> Right Nothing
+            Nothing    -> result
       | otherwise -> pure result
 
 findAllSql ::

--- a/src/EulerHS/JsonbFallback.hs
+++ b/src/EulerHS/JsonbFallback.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Schema-tolerant Postgres reads: on @42703 column does not exist@ retry
@@ -28,13 +30,16 @@ import           Control.Exception                    (SomeException, try)
 import qualified Data.Aeson                           as A
 import qualified Data.Aeson.Key                       as AK
 import qualified Data.Aeson.KeyMap                    as AKM
+import qualified Data.HashMap.Strict                  as HM
 import           Data.Maybe                           (listToMaybe)
 import qualified Data.Pool                            as DP
 import qualified Data.Text                            as T
 import qualified Data.Text.Encoding                   as TE
 import qualified Database.Beam.Postgres               as BP
-import           Database.Beam.Schema.Tables          (TableField (..),
+import           Database.Beam.Schema.Tables          (Columnar' (..),
+                                                       TableField (..),
                                                        TableSettings,
+                                                       allBeamValues,
                                                        dbTableSettings)
 import qualified Database.PostgreSQL.Simple           as PGS
 import           Database.PostgreSQL.Simple.Types     (Query (..))
@@ -45,6 +50,7 @@ import           EulerHS.Prelude                      hiding (try)
 import           EulerHS.SqlDB.Types                  (DBConfig,
                                                        NativeSqlPool (..),
                                                        SqlConn, bemToNative)
+import qualified GHC.Generics                         as G
 import           Sequelize                            (Clause (..), Column,
                                                        Model, ModelMeta,
                                                        Term (..), Where,
@@ -66,9 +72,8 @@ data JsonbFallbackError
   deriving stock    (Show, Generic)
   deriving anyclass (A.ToJSON)
 
--- | Log the original Postgres error and bump @kv_jsonb_fallback_counter@
--- BEFORE the retry runs. Gated by @KV_METRIC_ENABLED@ via the same
--- 'KVMetricCfg' / 'L.getOption' dispatch as 'incrementRedisCallMetric'.
+-- | Emit a structured error log and bump @kv_jsonb_fallback_counter@ BEFORE
+-- the retry runs. The metric is ungated (rare, high-signal event).
 fireFallbackHook
   :: forall table m
    . (HasCallStack, L.MonadFlow m, ModelMeta table)
@@ -85,13 +90,9 @@ fireFallbackHook errText = do
   L.logErrorV ("JsonbFallbackTriggered" :: Text) payload
   KVM.incrementJsonbFallbackMetric schema tbl errText
 
---------------------------------------------------------------------------------
--- WHERE rendering: Sequelize 'Where' → raw SQL fragment.
---
 -- Sequelize's @valueToText = T.pack . show@ wraps text literals in escaped
--- quotes (@"M1"@ → @"\"M1\""@); 'unShowText' strips that so the resulting
--- SQL matches what beam would have produced.
---------------------------------------------------------------------------------
+-- quotes (@"M1"@ → @"\"M1\""@); 'unShowText' strips that so the SQL matches
+-- what beam would have produced.
 
 columnName
   :: forall table value. (Model BP.Postgres table)
@@ -114,19 +115,19 @@ quoteIdent     t = "\"" <> T.replace "\"" "\"\"" t <> "\""
 
 sqlLit, sqlInList :: SQLObject a -> Text
 sqlLit = \case
-  SQLObjectValue v  -> quoteSqlString (unShowText v)
-  SQLObjectList xs  -> "ARRAY[" <> T.intercalate "," (map sqlLit xs) <> "]"
+  SQLObjectValue v -> quoteSqlString (unShowText v)
+  SQLObjectList xs -> "ARRAY[" <> T.intercalate "," (map sqlLit xs) <> "]"
 sqlInList = \case
-  SQLObjectValue v  -> "(" <> quoteSqlString (unShowText v) <> ")"
-  SQLObjectList xs  -> "(" <> T.intercalate "," (map sqlLit xs) <> ")"
+  SQLObjectValue v -> "(" <> quoteSqlString (unShowText v) <> ")"
+  SQLObjectList xs -> "(" <> T.intercalate "," (map sqlLit xs) <> ")"
 
 renderWhere
   :: forall table. (Model BP.Postgres table)
   => Where BP.Postgres table -> Either JsonbFallbackError Text
 renderWhere = \case
-  []       -> Right "TRUE"
-  [c]      -> renderClause c
-  cs       -> renderClause (And cs)
+  []  -> Right "TRUE"
+  [c] -> renderClause c
+  cs  -> renderClause (And cs)
   where
     renderClause :: Clause BP.Postgres table -> Either JsonbFallbackError Text
     renderClause = \case
@@ -160,30 +161,56 @@ renderWhere = \case
         Null  -> Right $ quoteIdent c <> " IS NOT NULL"
         other -> (\inner' -> "NOT (" <> inner' <> ")") <$> renderTerm c other
 
---------------------------------------------------------------------------------
--- Execute SELECT to_jsonb(t.*) and decode rows
---------------------------------------------------------------------------------
+-- | Walk a record's 'G.Rep' to extract Haskell record-selector names in
+-- declaration order. Used on @table Identity@ to get the camelCase field
+-- names that @genericParseJSON defaultOptions@ expects.
+class GFieldNames (f :: Type -> Type) where
+  gFieldNames :: Proxy f -> [Text]
 
--- | Normalise a row JSON value for downstream @FromJSON@. All transforms
--- apply ONLY to top-level column values — nested objects / arrays are user
--- payload (JSONB / @text[]@) and must stay byte-identical.
+instance GFieldNames G.U1                                  where gFieldNames _ = []
+instance G.Selector s => GFieldNames (G.M1 G.S s a)         where gFieldNames _ = [T.pack (G.selName (undefined :: G.M1 G.S s a x))]
+instance (GFieldNames f, GFieldNames g) => GFieldNames (f G.:*: g) where gFieldNames _ = gFieldNames (Proxy @f) <> gFieldNames (Proxy @g)
+instance GFieldNames f => GFieldNames (G.M1 G.D s f)        where gFieldNames _ = gFieldNames (Proxy @f)
+instance GFieldNames f => GFieldNames (G.M1 G.C s f)        where gFieldNames _ = gFieldNames (Proxy @f)
+
+-- | @<db-column-name> → <haskell-record-selector-name>@. DB names from
+-- 'modelFieldModification' (covers @mkTableInstancesWithTModifier@ overrides),
+-- Haskell names from 'GHC.Generics'; paired in beam's structural order.
+fieldNameMap
+  :: forall table
+   . (Model BP.Postgres table, G.Generic (table Identity), GFieldNames (G.Rep (table Identity)))
+  => HM.HashMap Text Text
+fieldNameMap =
+  let modSettings :: TableSettings table
+      modSettings = dbTableSettings (modelTableEntityDescriptor @table @BP.Postgres)
+      pick :: forall a. Columnar' (TableField table) a -> Text
+      pick (Columnar' f) = _fieldName f
+   in HM.fromList $ zip (allBeamValues pick modSettings)
+                        (gFieldNames (Proxy @(G.Rep (table Identity))))
+
+-- | Normalise a row Value for the table's auto-derived @FromJSON@. All
+-- transforms are top-level only — nested objects / arrays (JSONB columns,
+-- text[] arrays) stay byte-identical.
 --
--- 1. Rewrite top-level keys @snake_case → camelCase@ so the
---    @mkTableInstances@-generated @genericParseJSON defaultOptions@ instances
---    (which expect Haskell field names) decode unchanged.
--- 2. Strip the Postgres bytea text-format @\\x@ prefix from string values
---    (@"\\xdeadbeef" → "deadbeef"@) so @DbHash@-style @decodeHex@ accepts them.
--- 3. Unwrap @TEXT@ columns that hold a serialised JSON object / array (the
---    @mkBeamInstancesForJSON@ shape) — @to_jsonb@ emits them as JSON strings
---    @\"{...}\"@, the type's auto-derived FromJSON expects the structured
---    Value. We parse and substitute only when the inner parse yields an
---    Object or Array (scalar-looking strings are left untouched).
-normaliseRow :: A.Value -> A.Value
+-- * Key: DB column name → Haskell selector name via 'fieldNameMap'; falls
+--   back to snake↔camel for any column not in the map.
+-- * Value: 'unbyteaEncode' strips bytea's @\\x@ prefix; 'unwrapJsonText'
+--   promotes TEXT-stored JSON objects/arrays so @mkBeamInstancesForJSON@
+--   FromJSON instances receive the structured Value, not a JSON string.
+normaliseRow
+  :: forall table
+   . (Model BP.Postgres table, G.Generic (table Identity), GFieldNames (G.Rep (table Identity)))
+  => A.Value -> A.Value
 normaliseRow = \case
   A.Object o -> A.Object $ AKM.fromList
-    [ (AK.fromText (T.pack (Casing.camel (T.unpack (AK.toText k)))), normaliseValue v)
-    | (k, v) <- AKM.toList o ]
-  other      -> other
+    [ (renameKey (AK.toText k), normaliseValue v)
+    | (k, v) <- AKM.toList o
+    ]
+  other -> other
+  where
+    nameMap = fieldNameMap @table
+    renameKey dbCol = AK.fromText $
+      HM.lookupDefault (T.pack (Casing.camel (T.unpack dbCol))) dbCol nameMap
 
 normaliseValue :: A.Value -> A.Value
 normaliseValue = unwrapJsonText . unbyteaEncode
@@ -200,9 +227,6 @@ unbyteaEncode = \case
                || (c >= 'a' && c <= 'f')
                || (c >= 'A' && c <= 'F')
 
--- | Promote @TEXT@-stored JSON to its parsed Value, but only when the string
--- starts with @{@ or @[@ and parses to a structured value. Plain strings
--- (even those starting with other JSON-prefix characters) are preserved.
 unwrapJsonText :: A.Value -> A.Value
 unwrapJsonText = \case
   A.String t
@@ -217,9 +241,16 @@ unwrapJsonText = \case
     structured (A.Array  _) = True
     structured _            = False
 
+type JsonbDecodeable table =
+  ( Model BP.Postgres table
+  , A.FromJSON (table Identity)
+  , G.Generic (table Identity)
+  , GFieldNames (G.Rep (table Identity))
+  )
+
 runJsonbSelect
   :: forall table m
-   . (HasCallStack, L.MonadFlow m, A.FromJSON (table Identity))
+   . (HasCallStack, L.MonadFlow m, JsonbDecodeable table)
   => DBConfig BP.Pg -> Text
   -> m (Either JsonbFallbackError [table Identity])
 runJsonbSelect dbConf sql = do
@@ -237,7 +268,7 @@ runJsonbSelect dbConf sql = do
   where
     decodeRows :: [A.Value] -> [table Identity] -> Either JsonbFallbackError [table Identity]
     decodeRows []     acc = Right (reverse acc)
-    decodeRows (v:vs) acc = case A.fromJSON (normaliseRow v) of
+    decodeRows (v:vs) acc = case A.fromJSON (normaliseRow @table v) of
       A.Success r -> decodeRows vs (r : acc)
       A.Error err -> Left (JfeJsonDecodeError (T.pack err))
 
@@ -248,7 +279,7 @@ qualifiedTableName = case modelSchemaName @table of
 
 findAllSqlJsonb
   :: forall table m
-   . (HasCallStack, L.MonadFlow m, Model BP.Postgres table, A.FromJSON (table Identity))
+   . (HasCallStack, L.MonadFlow m, JsonbDecodeable table)
   => DBConfig BP.Pg -> Where BP.Postgres table
   -> m (Either JsonbFallbackError [table Identity])
 findAllSqlJsonb dbConf w = case renderWhere @table w of
@@ -258,7 +289,7 @@ findAllSqlJsonb dbConf w = case renderWhere @table w of
 
 findOneSqlJsonb
   :: forall table m
-   . (HasCallStack, L.MonadFlow m, Model BP.Postgres table, A.FromJSON (table Identity))
+   . (HasCallStack, L.MonadFlow m, JsonbDecodeable table)
   => DBConfig BP.Pg -> Where BP.Postgres table
   -> m (Either JsonbFallbackError (Maybe (table Identity)))
 findOneSqlJsonb dbConf w = case renderWhere @table w of
@@ -266,12 +297,9 @@ findOneSqlJsonb dbConf w = case renderWhere @table w of
   Right s -> fmap listToMaybe <$> runJsonbSelect @table dbConf
     ("SELECT to_jsonb(t.*) FROM " <> qualifiedTableName @table <> " t WHERE " <> s <> " LIMIT 1")
 
---------------------------------------------------------------------------------
--- Backend-polymorphic dispatch used by CachedSqlDBQuery.{findAllSql,findOneSql}.
--- OVERLAPPABLE default returns Nothing (any backend); OVERLAPPING Pg+Postgres
--- specialization runs the to_jsonb fallback after firing the metric/log.
---------------------------------------------------------------------------------
-
+-- | Backend-polymorphic dispatch used inside @CachedSqlDBQuery.findAllSql@ /
+-- @findOneSql@. OVERLAPPABLE default = no-op (any backend);
+-- OVERLAPPING Pg+Postgres+FromJSON = runs the to_jsonb fallback.
 class TryJsonbFallback beM be table where
   tryJsonbFallback
     :: (HasCallStack, L.MonadFlow m, Model be table, ModelMeta table)
@@ -282,7 +310,10 @@ instance {-# OVERLAPPABLE #-} TryJsonbFallback beM be table where
   tryJsonbFallback _ _ _ = pure Nothing
 
 instance {-# OVERLAPPING #-}
-         (A.FromJSON (table Identity))
+         ( A.FromJSON (table Identity)
+         , G.Generic  (table Identity)
+         , GFieldNames (G.Rep (table Identity))
+         )
          => TryJsonbFallback BP.Pg BP.Postgres table where
   tryJsonbFallback dbConf w origErr = do
     fireFallbackHook @table origErr

--- a/src/EulerHS/JsonbFallback.hs
+++ b/src/EulerHS/JsonbFallback.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Schema-tolerant Postgres reads: on @42703 column does not exist@ retry
+-- via @SELECT to_jsonb(t.*)@ and decode through the table's @FromJSON@.
+-- Wired into 'EulerHS.CachedSqlDBQuery.findAllSql' / 'findOneSql' via the
+-- 'TryJsonbFallback' typeclass — external callers need no source changes.
+module EulerHS.JsonbFallback
+  ( TryJsonbFallback (..)
+  , findAllSqlJsonb
+  , findOneSqlJsonb
+  , fireFallbackHook
+  , renderWhere
+  , JsonbFallbackError (..)
+  ) where
+
+import           Control.Exception                    (SomeException, try)
+import qualified Data.Aeson                           as A
+import qualified Data.Aeson.Key                       as AK
+import qualified Data.Aeson.KeyMap                    as AKM
+import           Data.Maybe                           (listToMaybe)
+import qualified Data.Pool                            as DP
+import qualified Data.Text                            as T
+import qualified Data.Text.Encoding                   as TE
+import qualified Database.Beam.Postgres               as BP
+import           Database.Beam.Schema.Tables          (TableField (..),
+                                                       TableSettings,
+                                                       dbTableSettings)
+import qualified Database.PostgreSQL.Simple           as PGS
+import           Database.PostgreSQL.Simple.Types     (Query (..))
+import           EulerHS.Extra.Language               (getOrInitSqlConn)
+import qualified EulerHS.Framework.Language           as L
+import qualified EulerHS.KVConnector.Metrics          as KVM
+import           EulerHS.Prelude                      hiding (try)
+import           EulerHS.SqlDB.Types                  (DBConfig,
+                                                       NativeSqlPool (..),
+                                                       SqlConn, bemToNative)
+import           Sequelize                            (Clause (..), Column,
+                                                       Model, ModelMeta,
+                                                       Term (..), Where,
+                                                       columnize, fromColumnar',
+                                                       modelSchemaName,
+                                                       modelTableEntityDescriptor,
+                                                       modelTableName)
+import           Sequelize.SQLObject                  (SQLObject (..),
+                                                       ToSQLObject,
+                                                       convertToSQLObject)
+import qualified Text.Casing                          as Casing
+
+data JsonbFallbackError
+  = JfeConnectionInitFailed     Text
+  | JfeUnexpectedConnectionKind Text
+  | JfePostgresError            Text
+  | JfeJsonDecodeError          Text
+  | JfeUnsupportedWhereTerm     Text
+  deriving stock    (Show, Generic)
+  deriving anyclass (A.ToJSON)
+
+-- | Log the original Postgres error and bump @kv_jsonb_fallback_counter@
+-- BEFORE the retry runs. Gated by @KV_METRIC_ENABLED@ via the same
+-- 'KVMetricCfg' / 'L.getOption' dispatch as 'incrementRedisCallMetric'.
+fireFallbackHook
+  :: forall table m
+   . (HasCallStack, L.MonadFlow m, ModelMeta table)
+  => Text -> m ()
+fireFallbackHook errText = do
+  let schema  = fromMaybe "" (modelSchemaName @table)
+      tbl     = modelTableName  @table
+      payload = A.object
+        [ "schema" A..= schema
+        , "table"  A..= tbl
+        , "error"  A..= errText
+        , "action" A..= ("retrying_via_to_jsonb" :: Text)
+        ]
+  L.logErrorV ("JsonbFallbackTriggered" :: Text) payload
+  KVM.incrementJsonbFallbackMetric schema tbl errText
+
+--------------------------------------------------------------------------------
+-- WHERE rendering: Sequelize 'Where' → raw SQL fragment.
+--
+-- Sequelize's @valueToText = T.pack . show@ wraps text literals in escaped
+-- quotes (@"M1"@ → @"\"M1\""@); 'unShowText' strips that so the resulting
+-- SQL matches what beam would have produced.
+--------------------------------------------------------------------------------
+
+columnName
+  :: forall table value. (Model BP.Postgres table)
+  => Column table value -> Text
+columnName col =
+  let settings :: TableSettings table
+      settings = dbTableSettings (modelTableEntityDescriptor @table @BP.Postgres)
+      field    = fromColumnar' (col (columnize settings)) :: TableField table value
+   in _fieldName field
+
+unShowText :: Text -> Text
+unShowText t
+  | T.length t >= 2, T.head t == '"', T.last t == '"' =
+      T.replace "\\\"" "\"" $ T.init (T.tail t)
+  | otherwise = t
+
+quoteSqlString, quoteIdent :: Text -> Text
+quoteSqlString t = "'"  <> T.replace "'"  "''"   t <> "'"
+quoteIdent     t = "\"" <> T.replace "\"" "\"\"" t <> "\""
+
+sqlLit, sqlInList :: SQLObject a -> Text
+sqlLit = \case
+  SQLObjectValue v  -> quoteSqlString (unShowText v)
+  SQLObjectList xs  -> "ARRAY[" <> T.intercalate "," (map sqlLit xs) <> "]"
+sqlInList = \case
+  SQLObjectValue v  -> "(" <> quoteSqlString (unShowText v) <> ")"
+  SQLObjectList xs  -> "(" <> T.intercalate "," (map sqlLit xs) <> ")"
+
+renderWhere
+  :: forall table. (Model BP.Postgres table)
+  => Where BP.Postgres table -> Either JsonbFallbackError Text
+renderWhere = \case
+  []       -> Right "TRUE"
+  [c]      -> renderClause c
+  cs       -> renderClause (And cs)
+  where
+    renderClause :: Clause BP.Postgres table -> Either JsonbFallbackError Text
+    renderClause = \case
+      And cs    -> joinClauses " AND " cs
+      Or  cs    -> joinClauses " OR "  cs
+      Is col tm -> renderTerm (columnName @table col) tm
+
+    joinClauses :: Text -> [Clause BP.Postgres table] -> Either JsonbFallbackError Text
+    joinClauses sep cs = do
+      parts <- traverse renderClause cs
+      pure $ case parts of
+        []  -> "TRUE"
+        [x] -> x
+        xs  -> "(" <> T.intercalate (")" <> sep <> "(") xs <> ")"
+
+    renderTerm
+      :: forall v. (ToSQLObject v)
+      => Text -> Term BP.Postgres v -> Either JsonbFallbackError Text
+    renderTerm c = \case
+      Eq v              -> Right $ quoteIdent c <> " = "    <> sqlLit    (convertToSQLObject v)
+      In vs             -> Right $ quoteIdent c <> " IN "   <> sqlInList (convertToSQLObject vs)
+      Null              -> Right $ quoteIdent c <> " IS NULL"
+      GreaterThan v     -> Right $ quoteIdent c <> " > "    <> sqlLit (convertToSQLObject v)
+      GreaterThanOrEq v -> Right $ quoteIdent c <> " >= "   <> sqlLit (convertToSQLObject v)
+      LessThan v        -> Right $ quoteIdent c <> " < "    <> sqlLit (convertToSQLObject v)
+      LessThanOrEq v    -> Right $ quoteIdent c <> " <= "   <> sqlLit (convertToSQLObject v)
+      Like t            -> Right $ quoteIdent c <> " LIKE " <> quoteSqlString t
+      Not inner -> case inner of
+        Eq v  -> Right $ quoteIdent c <> " <> "     <> sqlLit    (convertToSQLObject v)
+        In vs -> Right $ quoteIdent c <> " NOT IN " <> sqlInList (convertToSQLObject vs)
+        Null  -> Right $ quoteIdent c <> " IS NOT NULL"
+        other -> (\inner' -> "NOT (" <> inner' <> ")") <$> renderTerm c other
+
+--------------------------------------------------------------------------------
+-- Execute SELECT to_jsonb(t.*) and decode rows
+--------------------------------------------------------------------------------
+
+-- | Postgres @to_jsonb(t.*)@ emits column names verbatim (snake_case).
+-- @mkTableInstances@-generated FromJSON uses @genericParseJSON defaultOptions@
+-- which expects Haskell field names (camelCase). Rewrite ONLY top-level keys —
+-- nested objects / arrays are user payload (JSONB columns, text[] arrays) and
+-- must not be touched.
+snakeKeysToCamel :: A.Value -> A.Value
+snakeKeysToCamel = \case
+  A.Object o -> A.Object $ AKM.fromList
+    [ (AK.fromText (T.pack (Casing.camel (T.unpack (AK.toText k)))), v)
+    | (k, v) <- AKM.toList o ]
+  other      -> other
+
+runJsonbSelect
+  :: forall table m
+   . (HasCallStack, L.MonadFlow m, A.FromJSON (table Identity))
+  => DBConfig BP.Pg -> Text
+  -> m (Either JsonbFallbackError [table Identity])
+runJsonbSelect dbConf sql = do
+  eConn <- getOrInitSqlConn dbConf
+  case eConn of
+    Left e -> pure $ Left $ JfeConnectionInitFailed (T.pack (show e))
+    Right (conn :: SqlConn BP.Pg) -> case bemToNative conn of
+      NativePGPool pool -> do
+        ePg <- L.runIO $ try $ DP.withResource pool $ \pgConn ->
+          PGS.query_ pgConn (Query (TE.encodeUtf8 sql)) :: IO [PGS.Only A.Value]
+        case ePg of
+          Left  (e :: SomeException) -> pure $ Left $ JfePostgresError (T.pack (show e))
+          Right onlys                -> pure $ decodeRows (map PGS.fromOnly onlys) []
+      _ -> pure $ Left $ JfeUnexpectedConnectionKind "expected NativePGPool"
+  where
+    decodeRows :: [A.Value] -> [table Identity] -> Either JsonbFallbackError [table Identity]
+    decodeRows []     acc = Right (reverse acc)
+    decodeRows (v:vs) acc = case A.fromJSON (snakeKeysToCamel v) of
+      A.Success r -> decodeRows vs (r : acc)
+      A.Error err -> Left (JfeJsonDecodeError (T.pack err))
+
+qualifiedTableName :: forall table. ModelMeta table => Text
+qualifiedTableName = case modelSchemaName @table of
+  Just s  -> quoteIdent s <> "." <> quoteIdent (modelTableName @table)
+  Nothing -> quoteIdent (modelTableName @table)
+
+findAllSqlJsonb
+  :: forall table m
+   . (HasCallStack, L.MonadFlow m, Model BP.Postgres table, A.FromJSON (table Identity))
+  => DBConfig BP.Pg -> Where BP.Postgres table
+  -> m (Either JsonbFallbackError [table Identity])
+findAllSqlJsonb dbConf w = case renderWhere @table w of
+  Left e  -> pure (Left e)
+  Right s -> runJsonbSelect @table dbConf $
+    "SELECT to_jsonb(t.*) FROM " <> qualifiedTableName @table <> " t WHERE " <> s
+
+findOneSqlJsonb
+  :: forall table m
+   . (HasCallStack, L.MonadFlow m, Model BP.Postgres table, A.FromJSON (table Identity))
+  => DBConfig BP.Pg -> Where BP.Postgres table
+  -> m (Either JsonbFallbackError (Maybe (table Identity)))
+findOneSqlJsonb dbConf w = case renderWhere @table w of
+  Left e  -> pure (Left e)
+  Right s -> fmap listToMaybe <$> runJsonbSelect @table dbConf
+    ("SELECT to_jsonb(t.*) FROM " <> qualifiedTableName @table <> " t WHERE " <> s <> " LIMIT 1")
+
+--------------------------------------------------------------------------------
+-- Backend-polymorphic dispatch used by CachedSqlDBQuery.{findAllSql,findOneSql}.
+-- OVERLAPPABLE default returns Nothing (any backend); OVERLAPPING Pg+Postgres
+-- specialization runs the to_jsonb fallback after firing the metric/log.
+--------------------------------------------------------------------------------
+
+class TryJsonbFallback beM be table where
+  tryJsonbFallback
+    :: (HasCallStack, L.MonadFlow m, Model be table, ModelMeta table)
+    => DBConfig beM -> Where be table -> Text
+    -> m (Maybe [table Identity])
+
+instance {-# OVERLAPPABLE #-} TryJsonbFallback beM be table where
+  tryJsonbFallback _ _ _ = pure Nothing
+
+instance {-# OVERLAPPING #-}
+         (A.FromJSON (table Identity))
+         => TryJsonbFallback BP.Pg BP.Postgres table where
+  tryJsonbFallback dbConf w origErr = do
+    fireFallbackHook @table origErr
+    eRes <- findAllSqlJsonb @table dbConf w
+    pure $ case eRes of
+      Right rs -> Just rs
+      Left  _  -> Nothing

--- a/src/EulerHS/JsonbFallback.hs
+++ b/src/EulerHS/JsonbFallback.hs
@@ -164,17 +164,58 @@ renderWhere = \case
 -- Execute SELECT to_jsonb(t.*) and decode rows
 --------------------------------------------------------------------------------
 
--- | Postgres @to_jsonb(t.*)@ emits column names verbatim (snake_case).
--- @mkTableInstances@-generated FromJSON uses @genericParseJSON defaultOptions@
--- which expects Haskell field names (camelCase). Rewrite ONLY top-level keys —
--- nested objects / arrays are user payload (JSONB columns, text[] arrays) and
--- must not be touched.
-snakeKeysToCamel :: A.Value -> A.Value
-snakeKeysToCamel = \case
+-- | Normalise a row JSON value for downstream @FromJSON@. All transforms
+-- apply ONLY to top-level column values — nested objects / arrays are user
+-- payload (JSONB / @text[]@) and must stay byte-identical.
+--
+-- 1. Rewrite top-level keys @snake_case → camelCase@ so the
+--    @mkTableInstances@-generated @genericParseJSON defaultOptions@ instances
+--    (which expect Haskell field names) decode unchanged.
+-- 2. Strip the Postgres bytea text-format @\\x@ prefix from string values
+--    (@"\\xdeadbeef" → "deadbeef"@) so @DbHash@-style @decodeHex@ accepts them.
+-- 3. Unwrap @TEXT@ columns that hold a serialised JSON object / array (the
+--    @mkBeamInstancesForJSON@ shape) — @to_jsonb@ emits them as JSON strings
+--    @\"{...}\"@, the type's auto-derived FromJSON expects the structured
+--    Value. We parse and substitute only when the inner parse yields an
+--    Object or Array (scalar-looking strings are left untouched).
+normaliseRow :: A.Value -> A.Value
+normaliseRow = \case
   A.Object o -> A.Object $ AKM.fromList
-    [ (AK.fromText (T.pack (Casing.camel (T.unpack (AK.toText k)))), v)
+    [ (AK.fromText (T.pack (Casing.camel (T.unpack (AK.toText k)))), normaliseValue v)
     | (k, v) <- AKM.toList o ]
   other      -> other
+
+normaliseValue :: A.Value -> A.Value
+normaliseValue = unwrapJsonText . unbyteaEncode
+
+unbyteaEncode :: A.Value -> A.Value
+unbyteaEncode = \case
+  A.String t
+    | Just rest <- T.stripPrefix "\\x" t
+    , not (T.null rest)
+    , T.all isHexChar rest -> A.String rest
+  other -> other
+  where
+    isHexChar c = (c >= '0' && c <= '9')
+               || (c >= 'a' && c <= 'f')
+               || (c >= 'A' && c <= 'F')
+
+-- | Promote @TEXT@-stored JSON to its parsed Value, but only when the string
+-- starts with @{@ or @[@ and parses to a structured value. Plain strings
+-- (even those starting with other JSON-prefix characters) are preserved.
+unwrapJsonText :: A.Value -> A.Value
+unwrapJsonText = \case
+  A.String t
+    | not (T.null t)
+    , T.head t == '{' || T.head t == '['
+    , Right parsed <- A.eitherDecodeStrict (TE.encodeUtf8 t)
+    , structured parsed
+    -> parsed
+  other -> other
+  where
+    structured (A.Object _) = True
+    structured (A.Array  _) = True
+    structured _            = False
 
 runJsonbSelect
   :: forall table m
@@ -196,7 +237,7 @@ runJsonbSelect dbConf sql = do
   where
     decodeRows :: [A.Value] -> [table Identity] -> Either JsonbFallbackError [table Identity]
     decodeRows []     acc = Right (reverse acc)
-    decodeRows (v:vs) acc = case A.fromJSON (snakeKeysToCamel v) of
+    decodeRows (v:vs) acc = case A.fromJSON (normaliseRow v) of
       A.Success r -> decodeRows vs (r : acc)
       A.Error err -> Left (JfeJsonDecodeError (T.pack err))
 

--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -36,6 +36,7 @@ import EulerHS.CachedSqlDBQuery
       createSqlWoReturing,
       updateOneSqlWoReturning,
       SqlReturning(..) )
+import qualified EulerHS.JsonbFallback as JF
 import           EulerHS.KVConnector.Types (DBCommandVersion (..), KVConnector(..), MeshConfig(..), MeshResult, MeshError(..), MeshMeta(..), SecondaryKey(..), tableName, keyMap, Source(..), TableMappings(..))
 import           EulerHS.KVConnector.DBSync (getCreateQuery, getUpdateQuery, getDeleteQuery, getDbDeleteCommandJson, getDbUpdateCommandJson, getDbUpdateCommandJsonWithPrimaryKey, getDbDeleteCommandJsonWithPrimaryKey,getCreateQueryWithCompression, getDeleteQueryWithCompression, getUpdateQueryWithCompression)
 import           EulerHS.KVConnector.InMemConfig.Flow (searchInMemoryCache, pushToInMemConfigStream, fetchRowFromDBAndAlterImc)
@@ -564,7 +565,8 @@ updateAllReturningWithKVConnector :: forall table m.
     TableMappings (table Identity),
     Serialize.Serialize (table Identity),
     Show (table Identity), --debugging purpose
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback BP.Pg BP.Postgres table
   ) =>
   DBConfig BP.Pg ->
   DBConfig BP.Pg ->
@@ -616,7 +618,8 @@ updateAllWithKVConnector :: forall be table beM m.
     ToJSON (table Identity),
     Serialize.Serialize (table Identity),
     Show (table Identity), --debugging purpose
-    L.MonadFlow m
+    L.MonadFlow m,
+    JF.TryJsonbFallback beM be table
   ) =>
   DBConfig beM ->
   DBConfig beM ->
@@ -1317,7 +1320,8 @@ findAllWithKVConnector :: forall be table beM m.
     ToJSON (table Identity),
     FromJSON (table Identity),
     Serialize.Serialize (table Identity),
-    L.MonadFlow m, B.HasQBuilder be, BeamRunner beM) =>
+    L.MonadFlow m, B.HasQBuilder be, BeamRunner beM,
+    JF.TryJsonbFallback beM be table) =>
   DBConfig beM ->
   MeshConfig ->
   Where be table ->
@@ -1671,7 +1675,8 @@ deleteAllReturningWithKVConnector :: forall be table beM m.
     FromJSON (table Identity),
     Show (table Identity),
     Serialize.Serialize (table Identity),
-    L.MonadFlow m, B.HasQBuilder be, BeamRunner beM) =>
+    L.MonadFlow m, B.HasQBuilder be, BeamRunner beM,
+    JF.TryJsonbFallback beM be table) =>
   DBConfig beM ->
   MeshConfig ->
   Where be table ->

--- a/src/EulerHS/KVConnector/Metrics.hs
+++ b/src/EulerHS/KVConnector/Metrics.hs
@@ -33,7 +33,8 @@ data KVMetricHandler = KVMetricHandler
     kvCalls :: (Text, Text, Text, Int, Bool, Bool) -> IO (),
     compressionLatency :: (Text, Text, Text, NominalDiffTime) -> IO (),
     handlerLatency :: (Text, Text, Double, Text, Text) -> IO (),
-    kvHitMiss :: (Text, Text, KVFindResult) -> IO ()
+    kvHitMiss :: (Text, Text, KVFindResult) -> IO (),
+    jsonbFallback :: (Text, Text, Text) -> IO ()
   }
 
 data KVFindResult = KVHit | MissInKV | MissInDB
@@ -73,6 +74,10 @@ mkKVMetricHandler = do
               KVHit    -> inc (metrics </> #kv_hit_counter) action model
               MissInKV -> inc (metrics </> #kv_miss_in_kv_counter) action model
               MissInDB -> inc (metrics </> #kv_miss_in_db_counter) action model
+      )
+      ( \case
+          (schema, model, _err) ->
+            inc (metrics </> #kv_jsonb_fallback_counter) schema model
       )
 
 kv_compression_latency_observer =
@@ -156,6 +161,12 @@ kv_miss_in_db_counter =
     .& lbl @"model" @Text
     .& build
 
+kv_jsonb_fallback_counter =
+  counter #kv_jsonb_fallback_counter
+    .& lbl @"schema" @Text
+    .& lbl @"model" @Text
+    .& build
+
 collectionLock =
   kv_sql_error_counter
     .> kvRedis_soft_db_limit_exceeded
@@ -165,6 +176,7 @@ collectionLock =
     .> kv_hit_counter
     .> kv_miss_in_kv_counter
     .> kv_miss_in_db_counter
+    .> kv_jsonb_fallback_counter
     .> MNil
 
 
@@ -237,6 +249,13 @@ incrementKVHitMissMetric action model findResult = when isKVMetricEnabled $ do
   env <- L.getOption KVMetricCfg
   case env of
     Just val -> L.runIO $ kvHitMiss val (action, model, findResult)
+    Nothing -> pure ()
+
+incrementJsonbFallbackMetric :: (HasCallStack, L.MonadFlow m) => Text -> Text -> Text -> m ()
+incrementJsonbFallbackMetric schema model err = when isKVMetricEnabled $ do
+  env <- L.getOption KVMetricCfg
+  case env of
+    Just val -> L.runIO $ jsonbFallback val (schema, model, err)
     Nothing -> pure ()
 
 withKVLatencyMetric :: (HasCallStack, L.MonadFlow m) => Text -> Text -> Text -> m a -> m a

--- a/src/EulerHS/KVConnector/Metrics.hs
+++ b/src/EulerHS/KVConnector/Metrics.hs
@@ -252,11 +252,11 @@ incrementKVHitMissMetric action model findResult = when isKVMetricEnabled $ do
     Nothing -> pure ()
 
 incrementJsonbFallbackMetric :: (HasCallStack, L.MonadFlow m) => Text -> Text -> Text -> m ()
-incrementJsonbFallbackMetric schema model err = when isKVMetricEnabled $ do
+incrementJsonbFallbackMetric schema model err = do
   env <- L.getOption KVMetricCfg
   case env of
     Just val -> L.runIO $ jsonbFallback val (schema, model, err)
-    Nothing -> pure ()
+    Nothing  -> pure ()
 
 withKVLatencyMetric :: (HasCallStack, L.MonadFlow m) => Text -> Text -> Text -> m a -> m a
 withKVLatencyMetric handler model redisCluster action = do

--- a/test-jsonb-live/Main.hs
+++ b/test-jsonb-live/Main.hs
@@ -23,6 +23,9 @@ import qualified Data.Aeson                    as A
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
 import           Data.Time                     (UTCTime)
+import qualified Data.ByteString               as BS
+import qualified Data.ByteString.Base16        as B16
+import qualified Data.ByteString.Lazy          as BL
 import qualified Data.Vector                   as V
 import qualified Database.Beam                 as B
 import           Database.Beam.Backend.SQL.Row ()
@@ -62,9 +65,9 @@ data PersonT f = PersonT
   , isNew       :: B.C f Bool
   , createdAt   :: B.C f UTCTime
   , tags        :: B.C f (Maybe [Text])         -- text[]   array
-  , mobileHash  :: B.C f (Maybe Text)           -- bytea column; modelled as Maybe Text only for the FALLBACK path (to_jsonb -> "\\xdeadbeef"); normal beam path will type-mismatch (intentional)
+  , mobileHash  :: B.C f (Maybe HexBlob)        -- bytea column; HexBlob mirrors DbHash (hex string FromJSON + native bytea Beam IO)
   , metadata    :: B.C f (Maybe A.Value)        -- jsonb passthrough
-  , pref        :: B.C f (Maybe Text)           -- text storing JSON (mkBeamInstancesForJSON shape)
+  , pref        :: B.C f (Maybe VehiclePref)    -- text storing JSON (mkBeamInstancesForJSON shape): structured sum type
   } deriving (Generic, B.Beamable)
 
 instance B.Table PersonT where
@@ -100,6 +103,50 @@ instance ModelMeta PersonT where
 
 instance ToSQLObject Bool where
   convertToSQLObject = SQLObjectValue . T.pack . show
+
+-- | Stand-in for a @mkBeamInstancesForJSON@-style type: stored as TEXT
+-- containing a JSON-encoded sum-type. FromJSON expects an Object/Array, not
+-- a raw string — verifies the fallback's TEXT→JSON unwrap.
+data VehiclePref
+  = VehicleSedan [Text]
+  | VehicleAuto  Text
+  deriving (Eq, Show, Generic)
+instance A.FromJSON VehiclePref
+instance A.ToJSON VehiclePref
+
+instance PGS.FromField VehiclePref where
+  fromField f mb = do
+    bs :: BS.ByteString <- PGS.fromField f mb
+    case A.eitherDecodeStrict bs of
+      Right v -> pure v
+      Left  e -> PGS.returnError PGS.ConversionFailed f ("VehiclePref decode: " <> e)
+
+instance HasSqlValueSyntax PgValueSyntax VehiclePref where
+  sqlValueSyntax = sqlValueSyntax . TE.decodeUtf8 . BL.toStrict . A.encode
+
+instance B.FromBackendRow B.Postgres VehiclePref
+instance B.HasSqlEqualityCheck B.Postgres VehiclePref
+
+-- | Stand-in for shared-kernel's @DbHash@: bytea in PG, hex string in JSON.
+-- Verifies the fallback's @\\x@-prefix-strip lets DbHash-style FromJSON decode
+-- without the table needing any change.
+newtype HexBlob = HexBlob { unHexBlob :: BS.ByteString } deriving (Eq, Generic)
+
+instance Show HexBlob where show = T.unpack . TE.decodeUtf8 . B16.encode . unHexBlob
+
+instance A.FromJSON HexBlob where
+  parseJSON = A.withText "HexBlob" $ \t -> case B16.decode (TE.encodeUtf8 t) of
+    Right b -> pure (HexBlob b)
+    Left  e -> fail ("HexBlob: bad hex: " <> e)
+
+instance PGS.FromField HexBlob where
+  fromField f mb = HexBlob <$> PGS.fromField f mb
+
+instance HasSqlValueSyntax PgValueSyntax HexBlob where
+  sqlValueSyntax = sqlValueSyntax . unHexBlob
+
+instance B.FromBackendRow B.Postgres HexBlob
+instance B.HasSqlEqualityCheck B.Postgres HexBlob
 
 -- Orphan instances shared-kernel ships for text[] support
 -- (`Kernel.Types.Common` lines 159-170); duplicated here so the test exec
@@ -186,7 +233,7 @@ resetSchema = do
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS mobile_hash bytea"
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS metadata jsonb"
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS pref text"
-  runRaw "UPDATE atlas_driver_offer_bpp.person SET tags=ARRAY['vip','english']::text[], mobile_hash=E'\\\\xDEADBEEF'::bytea, metadata='{\"foo\":1}'::jsonb, pref='{\"Sedan\":[]}' WHERE id IN ('p1','p2')"
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET tags=ARRAY['vip','english']::text[], mobile_hash=E'\\\\xDEADBEEFCAFEBABE'::bytea, metadata='{\"foo\":1}'::jsonb, pref='{\"tag\":\"VehicleSedan\",\"contents\":[\"spacious\",\"quiet\"]}' WHERE id IN ('p1','p2')"
 
 dropCol :: Text -> IO ()
 dropCol col = runRaw ("ALTER TABLE atlas_driver_offer_bpp.person DROP COLUMN " <> col)

--- a/test-jsonb-live/Main.hs
+++ b/test-jsonb-live/Main.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE DuplicateRecordFields     #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE UndecidableInstances      #-}
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-orphans -Wno-name-shadowing -Wno-missing-signatures -Wno-incomplete-record-updates #-}
+
+module Main (main) where
+
+import           EulerHS.Prelude               hiding (id, show, putStrLn)
+import           Prelude                       (Show (show), String, putStrLn)
+import qualified Data.Aeson                    as A
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import           Data.Time                     (UTCTime)
+import qualified Data.Vector                   as V
+import qualified Database.Beam                 as B
+import           Database.Beam.Backend.SQL.Row ()
+import qualified Database.Beam.Schema.Tables   as BST
+import qualified Database.Beam.Postgres        as BP
+import qualified Database.Beam.Postgres        as B (Postgres)
+import           Database.Beam.Backend.SQL     (HasSqlValueSyntax (..))
+import           Database.Beam.Postgres.Syntax (PgValueSyntax, defaultPgValueSyntax)
+import qualified Database.PostgreSQL.Simple    as PGS
+import qualified Database.PostgreSQL.Simple.FromField as PGS
+import qualified Database.PostgreSQL.Simple.Types as PGS
+import           System.Environment            (setEnv)
+
+import qualified EulerHS.CachedSqlDBQuery      as DBQ
+import qualified EulerHS.Interpreters          as I
+import qualified EulerHS.KVConnector.Metrics   as KVM
+import qualified EulerHS.Language              as L
+import qualified EulerHS.Runtime               as R
+import           EulerHS.Types                 (DBConfig, PoolConfig (..),
+                                                PostgresConfig (..),
+                                                mkPostgresPoolConfig)
+import           Sequelize                     (Clause (..), Term (..), Where,
+                                                ModelMeta (..))
+import           Sequelize.SQLObject           (ToSQLObject (..),
+                                                SQLObject (..))
+
+-- =============================================================================
+-- Beam table mirroring atlas_driver_offer_bpp.person
+-- =============================================================================
+
+data PersonT f = PersonT
+  { id          :: B.C f Text
+  , firstName   :: B.C f Text
+  , lastName    :: B.C f (Maybe Text)
+  , description :: B.C f (Maybe Text)
+  , merchantId  :: B.C f Text
+  , isNew       :: B.C f Bool
+  , createdAt   :: B.C f UTCTime
+  , tags        :: B.C f (Maybe [Text])         -- text[]   array
+  , mobileHash  :: B.C f (Maybe Text)           -- bytea column; modelled as Maybe Text only for the FALLBACK path (to_jsonb -> "\\xdeadbeef"); normal beam path will type-mismatch (intentional)
+  , metadata    :: B.C f (Maybe A.Value)        -- jsonb passthrough
+  , pref        :: B.C f (Maybe Text)           -- text storing JSON (mkBeamInstancesForJSON shape)
+  } deriving (Generic, B.Beamable)
+
+instance B.Table PersonT where
+  data PrimaryKey PersonT f = PersonId (B.C f Text) deriving (Generic, B.Beamable)
+  primaryKey = PersonId . Main.id
+
+type Person = PersonT Identity
+
+deriving instance Show Person
+
+-- mkTableInstances-equivalent: genericParseJSON defaultOptions (expects
+-- camelCase Haskell field names). Verifies JsonbFallback's key-rewriter
+-- converts snake_case columns back to camelCase before decode.
+instance A.FromJSON Person where
+  parseJSON = A.genericParseJSON A.defaultOptions
+
+instance ModelMeta PersonT where
+  modelFieldModification = B.tableModification
+    { id          = B.fieldNamed "id"
+    , firstName   = B.fieldNamed "first_name"
+    , lastName    = B.fieldNamed "last_name"
+    , description = B.fieldNamed "description"
+    , merchantId  = B.fieldNamed "merchant_id"
+    , isNew       = B.fieldNamed "is_new"
+    , createdAt   = B.fieldNamed "created_at"
+    , tags        = B.fieldNamed "tags"
+    , mobileHash  = B.fieldNamed "mobile_hash"
+    , metadata    = B.fieldNamed "metadata"
+    , pref        = B.fieldNamed "pref"
+    }
+  modelTableName  = "person"
+  modelSchemaName = Just "atlas_driver_offer_bpp"
+
+instance ToSQLObject Bool where
+  convertToSQLObject = SQLObjectValue . T.pack . show
+
+-- Orphan instances shared-kernel ships for text[] support
+-- (`Kernel.Types.Common` lines 159-170); duplicated here so the test exec
+-- can link without depending on shared-kernel.
+instance HasSqlValueSyntax PgValueSyntax [Text] where
+  sqlValueSyntax xs = sqlValueSyntax (V.fromList xs)
+
+instance PGS.FromField [Text] where
+  fromField f mbValue = V.toList <$> PGS.fromField f mbValue
+
+instance B.FromBackendRow B.Postgres [Text]
+instance B.HasSqlEqualityCheck B.Postgres [Text]
+
+-- =============================================================================
+-- KV metric handler that records jsonb-fallback firings
+-- =============================================================================
+
+mkRecordingKvHandler :: IORef Int -> IO KVM.KVMetricHandler
+mkRecordingKvHandler ref = do
+  base <- KVM.mkKVMetricHandler
+  pure base { KVM.jsonbFallback = \(schema, table, err) -> do
+                putStrLn $
+                  "[live-test] >>> jsonbFallback metric: schema=" <> T.unpack schema
+                  <> " table=" <> T.unpack table
+                  <> " err=" <> T.unpack (T.take 140 err)
+                atomicModifyIORef' ref (\n -> (n + 1, ()))
+            }
+
+-- =============================================================================
+-- Connection + flow runner
+-- =============================================================================
+
+dbConf :: DBConfig BP.Pg
+dbConf =
+  mkPostgresPoolConfig "jsonb-live-test"
+    PostgresConfig
+      { connectHost     = "localhost"
+      , connectPort     = 5432
+      , connectUser     = "postgres"
+      , connectPassword = ""
+      , connectDatabase = "atlas_driver_offer_bpp_v1"
+      }
+    PoolConfig
+      { stripes            = 1
+      , keepAlive          = 10
+      , resourcesPerStripe = 4
+      }
+
+runFlow :: KVM.KVMetricHandler -> L.Flow a -> IO a
+runFlow handler flow =
+  R.withFlowRuntime Nothing $ \rt ->
+    I.runFlow rt $ do
+      _ <- L.initSqlDBConnection dbConf
+      L.setOption KVM.KVMetricCfg handler
+      flow
+
+-- =============================================================================
+-- WHERE merchant_id = 'M1' — matches 2 of 3 seeded rows
+-- =============================================================================
+
+whereM1 :: Where BP.Postgres PersonT
+whereM1 = [Is merchantId (Eq ("M1" :: Text))]
+
+wherePid :: Text -> Where BP.Postgres PersonT
+wherePid v = [Is Main.id (Eq v)]
+
+-- =============================================================================
+-- Schema mutation helpers (local sandbox)
+-- =============================================================================
+
+runRaw :: Text -> IO ()
+runRaw sql = do
+  c <- PGS.connectPostgreSQL "host=localhost port=5432 user=postgres dbname=atlas_driver_offer_bpp_v1"
+  _ <- PGS.execute_ c (PGS.Query (TE.encodeUtf8 sql))
+  PGS.close c
+
+resetSchema :: IO ()
+resetSchema = do
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS description varchar(255)"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS last_name   varchar(255)"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS first_name  varchar(255) NOT NULL DEFAULT 'X'"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ALTER COLUMN first_name DROP DEFAULT"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS tags text[]"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS mobile_hash bytea"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS metadata jsonb"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS pref text"
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET tags=ARRAY['vip','english']::text[], mobile_hash=E'\\\\xDEADBEEF'::bytea, metadata='{\"foo\":1}'::jsonb, pref='{\"Sedan\":[]}' WHERE id IN ('p1','p2')"
+
+dropCol :: Text -> IO ()
+dropCol col = runRaw ("ALTER TABLE atlas_driver_offer_bpp.person DROP COLUMN " <> col)
+
+-- =============================================================================
+-- Test cases
+-- =============================================================================
+
+reportEither :: Show e => String -> Either e [Person] -> IO Bool
+reportEither label = \case
+  Right rs -> do
+    putStrLn $ "  " <> label <> ": OK rows=" <> show (length rs)
+    forM_ rs $ \p ->
+      putStrLn $ "    - " <> T.unpack (Main.id p)
+              <> "  desc=" <> show (description p)
+              <> "  tags=" <> show (tags p)
+              <> "  mobileHash=" <> show (mobileHash p)
+              <> "  metadata=" <> show (metadata p)
+              <> "  pref=" <> show (pref p)
+    pure True
+  Left e -> do
+    putStrLn $ "  " <> label <> ": ERR " <> show e
+    pure False
+
+checkHits :: IORef Int -> Bool -> String -> IO Bool
+checkHits ref expected label = do
+  n <- readIORef ref
+  let ok = (n > 0) == expected
+  putStrLn $ "  " <> label <> " jsonbFallback hits=" <> show n
+           <> (if ok then " (expected)" else "  *** UNEXPECTED ***")
+  pure ok
+
+resetHits :: IORef Int -> IO ()
+resetHits ref = atomicModifyIORef' ref (const (0, ()))
+
+main :: IO ()
+main = do
+  setEnv "KV_METRIC_ENABLED" "True"
+  putStrLn "=== Live jsonb-fallback test against atlas_driver_offer_bpp.person ==="
+  resetSchema
+
+  hitRef  <- newIORef 0
+  handler <- mkRecordingKvHandler hitRef
+
+  putStrLn "\n[A] All columns present, normal findAllSql"
+  resetHits hitRef
+  rA <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okA1 <- reportEither "A" rA
+  okA2 <- checkHits hitRef False "A"
+
+  putStrLn "\n[B] DROP COLUMN description -> expect 42703 -> jsonb fallback"
+  dropCol "description"
+  resetHits hitRef
+  rB <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okB1 <- reportEither "B" rB
+  okB2 <- checkHits hitRef True "B"
+
+  putStrLn "\n[C] DROP COLUMN last_name also -> fallback again"
+  dropCol "last_name"
+  resetHits hitRef
+  rC <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okC1 <- reportEither "C" rC
+  okC2 <- checkHits hitRef True "C"
+
+  putStrLn "\n[D] DROP COLUMN first_name (required) -> must fail loudly"
+  dropCol "first_name"
+  resetHits hitRef
+  rD <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  let okD = case rD of Left _ -> True; Right _ -> False
+  putStrLn $ "  D: " <> (if okD then "OK loud failure" else "*** UNEXPECTED success: " <> show rD <> " ***")
+
+  putStrLn "\n[E] restore schema; findOneSql control"
+  resetSchema
+  resetHits hitRef
+  rE <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "p1")
+  let okE1 = case rE of
+        Right (Just p) -> Main.id p == "p1"
+        _              -> False
+  okE2 <- checkHits hitRef False "E"
+  putStrLn $ "  E -> " <> show rE
+
+  putStrLn "\n[F] DROP COLUMN description; findOneSql -> expect fallback"
+  dropCol "description"
+  resetHits hitRef
+  rF <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "p1")
+  let okF1 = case rF of
+        Right (Just _) -> True
+        _              -> False
+  okF2 <- checkHits hitRef True "F"
+  putStrLn $ "  F -> " <> show rF
+  resetSchema
+
+  putStrLn "\n[G] DROP COLUMN tags (text[] array) -> expect fallback ok"
+  resetSchema
+  dropCol "tags"
+  resetHits hitRef
+  rG <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okG1 <- reportEither "G" rG
+  okG2 <- checkHits hitRef True "G"
+
+  putStrLn "\n[H] DROP COLUMN metadata (jsonb Aeson.Value) -> expect fallback ok"
+  resetSchema
+  dropCol "metadata"
+  resetHits hitRef
+  rH <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okH1 <- reportEither "H" rH
+  okH2 <- checkHits hitRef True "H"
+
+  putStrLn "\n[I] DROP COLUMN mobile_hash (bytea -> JSON string \"\\\\xdeadbeef\") -> expect fallback ok (FromJSON Text accepts)"
+  resetSchema
+  dropCol "mobile_hash"
+  resetHits hitRef
+  rI <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okI1 <- reportEither "I" rI
+  okI2 <- checkHits hitRef True "I"
+
+  putStrLn "\n[J] DROP COLUMN pref (text storing JSON, mkBeamInstancesForJSON shape) -> Maybe Text accepts ok"
+  resetSchema
+  dropCol "pref"
+  resetHits hitRef
+  rJ <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  okJ1 <- reportEither "J" rJ
+  okJ2 <- checkHits hitRef True "J"
+
+  resetSchema
+
+  let results = [okA1, okA2, okB1, okB2, okC1, okC2, okD, okE1, okE2, okF1, okF2,
+                 okG1, okG2, okH1, okH2, okI1, okI2, okJ1, okJ2]
+      passed = length (filter (== True) results)
+  putStrLn $ "\n=== Summary: " <> show passed <> "/" <> show (length results) <> " passed ==="
+  unless (and results) exitFailure

--- a/test-jsonb-live/Main.hs
+++ b/test-jsonb-live/Main.hs
@@ -23,6 +23,8 @@ import qualified Data.Aeson                    as A
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
 import           Data.Time                     (UTCTime)
+import           Control.Concurrent.Async      (mapConcurrently)
+import qualified Data.Aeson.KeyMap             as AKM
 import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Base16        as B16
 import qualified Data.ByteString.Lazy          as BL
@@ -103,7 +105,7 @@ instance ModelMeta PersonT where
   modelTableName  = "person"
   modelSchemaName = Just "atlas_driver_offer_bpp"
 
-instance ToSQLObject Bool where
+instance {-# OVERLAPPING #-} ToSQLObject Bool where
   convertToSQLObject = SQLObjectValue . T.pack . show
 
 -- | Stand-in for a @mkBeamInstancesForJSON@-style type: stored as TEXT
@@ -377,9 +379,135 @@ main = do
   putStrLn $ "  K override-mapped value preserved: " <> show valuesOK
   resetSchema
 
+  -- ============================================================
+  -- Production-readiness deep tests
+  -- ============================================================
+
+  putStrLn "\n[L] Nested JSONB containing snake_case keys MUST NOT be camelized (user payload safety)"
+  resetSchema
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET metadata='{\"first_name\":\"nested\",\"deep\":{\"another_key\":42},\"arr\":[{\"snake_case_in_array\":true}]}'::jsonb WHERE id='p1'"
+  dropCol "description"
+  resetHits hitRef
+  rL <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "p1")
+  let okL = case rL of
+        Right (Just p) -> case metadata p of
+          Just (A.Object o) ->
+            AKM.lookup "first_name" o == Just (A.String "nested") &&
+            (case AKM.lookup "deep" o of
+               Just (A.Object d) -> AKM.lookup "another_key" d == Just (A.Number 42)
+               _ -> False) &&
+            (case AKM.lookup "arr" o of
+               Just (A.Array _) -> True
+               _ -> False)
+          _ -> False
+        _ -> False
+  putStrLn $ "  L nested-payload integrity: " <> (if okL then "OK" else "*** CORRUPTED *** " <> show rL)
+  resetSchema
+
+  putStrLn "\n[M] Bytea-prefix strip MUST be guarded: text starting with \\x but non-hex stays as-is"
+  resetSchema
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET last_name='\\xnot-hex-text' WHERE id='p1'"
+  dropCol "tags"
+  resetHits hitRef
+  rM <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "p1")
+  let okM' = case rM of
+        Right (Just p) -> lastName p == Just "\\xnot-hex-text"
+        _ -> False
+  putStrLn $ "  M guarded bytea strip: " <> (if okM' then "OK preserved as-is" else "*** stripped non-hex *** " <> show rM)
+  resetSchema
+
+  putStrLn "\n[N] unwrapJsonText safety: text starting with { but invalid JSON stays as String"
+  resetSchema
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET last_name='{not valid json' WHERE id='p1'"
+  dropCol "tags"
+  resetHits hitRef
+  rN <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "p1")
+  let okN' = case rN of
+        Right (Just p) -> lastName p == Just "{not valid json"
+        _ -> False
+  putStrLn $ "  N guarded unwrapJsonText: " <> (if okN' then "OK preserved" else "*** corrupted *** " <> show rN)
+  resetSchema
+
+  putStrLn "\n[O] Non-42703 error MUST surface untouched (no fallback attempt)"
+  resetSchema
+  resetHits hitRef
+  rO <- runFlow handler $ DBQ.findAllSql dbConf
+          ([Is merchantId (Eq ("M_does_not_match'_INJECTION" :: Text))] :: Where BP.Postgres PersonT)
+  let okO = case rO of
+        Right rs -> length rs == 0
+        Left  _  -> False
+  okO2 <- checkHits hitRef False "O"
+  putStrLn $ "  O non-42703 path: rows=" <> show (case rO of Right rs -> length rs; _ -> -1) <> " unchanged=" <> show okO
+
+  putStrLn "\n[P] WHERE on override-mapped column (Eq on oldNightShiftCharge) — drop unrelated col, fallback uses override-aware columnName"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rP <- runFlow handler $ DBQ.findAllSql dbConf
+          ([Is merchantId (Eq ("M1" :: Text)), Is oldNightShiftCharge (Eq (Just 1.5 :: Maybe Double))] :: Where BP.Postgres PersonT)
+  let okP = case rP of
+        Right rs -> length rs == 2 && all (\p -> oldNightShiftCharge p == Just 1.5) rs
+        _ -> False
+  okP2 <- checkHits hitRef True "P"
+  putStrLn $ "  P override-col WHERE: " <> (if okP then "OK" else "*** miss *** " <> show rP)
+  resetSchema
+
+  putStrLn "\n[Q] Multi-clause WHERE (AND of two predicates) via fallback"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rQ <- runFlow handler $ DBQ.findAllSql dbConf
+          ([Is merchantId (Eq ("M1" :: Text)), Is isNew (Eq True)] :: Where BP.Postgres PersonT)
+  okQ1 <- reportEither "Q" rQ
+  okQ2 <- checkHits hitRef True "Q"
+
+  putStrLn "\n[R] SQL-injection probe in Eq literal — must be escaped, no rows match"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rR <- runFlow handler $ DBQ.findAllSql dbConf
+          ([Is merchantId (Eq ("M1' OR '1'='1" :: Text))] :: Where BP.Postgres PersonT)
+  let okR = case rR of
+        Right rs -> length rs == 0   -- escaped, no match
+        Left  _  -> True             -- also fine if it errors
+  okR2 <- checkHits hitRef True "R"
+  putStrLn $ "  R injection probe: rows=" <> show (case rR of Right rs -> length rs; _ -> -1)
+
+  putStrLn "\n[S] Zero-row fallback result returns Right []"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rS <- runFlow handler $ DBQ.findAllSql dbConf
+          ([Is merchantId (Eq ("MERCHANT_DOES_NOT_EXIST" :: Text))] :: Where BP.Postgres PersonT)
+  let okS = case rS of Right [] -> True; _ -> False
+  okS2 <- checkHits hitRef True "S"
+  putStrLn $ "  S zero-row: " <> (if okS then "OK Right []" else "*** unexpected *** " <> show rS)
+
+  putStrLn "\n[T] Concurrent fallbacks (10 in parallel) must all succeed"
+  resetSchema
+  dropCol "description"
+  results' <- mapConcurrently
+                (\_ -> runFlow handler $ DBQ.findAllSql dbConf whereM1)
+                [1 .. 10 :: Int]
+  let okT = all (\r -> case r of Right rs -> length rs == 2; _ -> False) results'
+  putStrLn $ "  T 10 concurrent calls: " <> show (length (filter (\r -> case r of Right _ -> True; _ -> False) results')) <> "/10 OK"
+  resetSchema
+
+  putStrLn "\n[U] findOneSql zero-row fallback returns Right Nothing"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rU <- runFlow handler $ DBQ.findOneSql dbConf (wherePid "ID_DOES_NOT_EXIST")
+  let okU = case rU of Right Nothing -> True; _ -> False
+  okU2 <- checkHits hitRef True "U"
+  putStrLn $ "  U findOneSql zero-row: " <> (if okU then "OK Right Nothing" else "*** unexpected *** " <> show rU)
+  resetSchema
+
   let results = [okA1, okA2, okB1, okB2, okC1, okC2, okD, okE1, okE2, okF1, okF2,
                  okG1, okG2, okH1, okH2, okI1, okI2, okJ1, okJ2,
-                 okK1, okK2, valuesOK]
+                 okK1, okK2, valuesOK,
+                 okL, okM', okN', okO, okO2, okP, okP2, okQ1, okQ2,
+                 okR, okR2, okS, okS2, okT, okU, okU2]
       passed = length (filter (== True) results)
   putStrLn $ "\n=== Summary: " <> show passed <> "/" <> show (length results) <> " passed ==="
   unless (and results) exitFailure

--- a/test-jsonb-live/Main.hs
+++ b/test-jsonb-live/Main.hs
@@ -68,6 +68,7 @@ data PersonT f = PersonT
   , mobileHash  :: B.C f (Maybe HexBlob)        -- bytea column; HexBlob mirrors DbHash (hex string FromJSON + native bytea Beam IO)
   , metadata    :: B.C f (Maybe A.Value)        -- jsonb passthrough
   , pref        :: B.C f (Maybe VehiclePref)    -- text storing JSON (mkBeamInstancesForJSON shape): structured sum type
+  , oldNightShiftCharge :: B.C f (Maybe Double) -- DB column is `night_shift_multiplier` (mirrors rider-app Estimate's mkTableInstancesWithTModifier override)
   } deriving (Generic, B.Beamable)
 
 instance B.Table PersonT where
@@ -97,6 +98,7 @@ instance ModelMeta PersonT where
     , mobileHash  = B.fieldNamed "mobile_hash"
     , metadata    = B.fieldNamed "metadata"
     , pref        = B.fieldNamed "pref"
+    , oldNightShiftCharge = B.fieldNamed "night_shift_multiplier"
     }
   modelTableName  = "person"
   modelSchemaName = Just "atlas_driver_offer_bpp"
@@ -233,7 +235,8 @@ resetSchema = do
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS mobile_hash bytea"
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS metadata jsonb"
   runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS pref text"
-  runRaw "UPDATE atlas_driver_offer_bpp.person SET tags=ARRAY['vip','english']::text[], mobile_hash=E'\\\\xDEADBEEFCAFEBABE'::bytea, metadata='{\"foo\":1}'::jsonb, pref='{\"tag\":\"VehicleSedan\",\"contents\":[\"spacious\",\"quiet\"]}' WHERE id IN ('p1','p2')"
+  runRaw "ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN IF NOT EXISTS night_shift_multiplier double precision"
+  runRaw "UPDATE atlas_driver_offer_bpp.person SET tags=ARRAY['vip','english']::text[], mobile_hash=E'\\\\xDEADBEEFCAFEBABE'::bytea, metadata='{\"foo\":1}'::jsonb, pref='{\"tag\":\"VehicleSedan\",\"contents\":[\"spacious\",\"quiet\"]}', night_shift_multiplier=1.5 WHERE id IN ('p1','p2')"
 
 dropCol :: Text -> IO ()
 dropCol col = runRaw ("ALTER TABLE atlas_driver_offer_bpp.person DROP COLUMN " <> col)
@@ -253,6 +256,7 @@ reportEither label = \case
               <> "  mobileHash=" <> show (mobileHash p)
               <> "  metadata=" <> show (metadata p)
               <> "  pref=" <> show (pref p)
+              <> "  oldNightShiftCharge=" <> show (oldNightShiftCharge p)
     pure True
   Left e -> do
     putStrLn $ "  " <> label <> ": ERR " <> show e
@@ -360,8 +364,22 @@ main = do
 
   resetSchema
 
+  putStrLn "\n[K] mkTableInstancesWithTModifier override (oldNightShiftCharge<->night_shift_multiplier): drop unrelated col, fallback must recover the override-mapped value"
+  resetSchema
+  dropCol "description"
+  resetHits hitRef
+  rK <- runFlow handler $ DBQ.findAllSql dbConf whereM1
+  let valuesOK = case rK of
+        Right rs -> all (\p -> oldNightShiftCharge p == Just 1.5) rs && length rs == 2
+        _        -> False
+  okK1 <- reportEither "K" rK
+  okK2 <- checkHits hitRef True "K"
+  putStrLn $ "  K override-mapped value preserved: " <> show valuesOK
+  resetSchema
+
   let results = [okA1, okA2, okB1, okB2, okC1, okC2, okD, okE1, okE2, okF1, okF2,
-                 okG1, okG2, okH1, okH2, okI1, okI2, okJ1, okJ2]
+                 okG1, okG2, okH1, okH2, okI1, okI2, okJ1, okJ2,
+                 okK1, okK2, valuesOK]
       passed = length (filter (== True) results)
   putStrLn $ "\n=== Summary: " <> show passed <> "/" <> show (length results) <> " passed ==="
   unless (and results) exitFailure


### PR DESCRIPTION
## Summary

Adds `EulerHS.JsonbFallback` — schema-tolerant Postgres reads that auto-retry on `42703 column does not exist` via `SELECT to_jsonb(t.*)` + the table's `FromJSON`. Wired transparently inside `CachedSqlDBQuery.findAllSql` / `findOneSql` via a `TryJsonbFallback` typeclass; **external callers (shared-kernel, Backend) need zero source changes**.

## Why

During rolling deploys with multi-cloud DB (AWS + GCP), the binary in one cloud may expect a column that hasn't been migrated yet on the other side. Today this surfaces as a hard `42703` and pages on-call. This change recovers transparently in the dominant case (new optional columns) and surfaces a metric/log so the divergence is visible.

## Mechanics

1. `is42703DBError` matches `"42703"` inside the `DBError` text (set by `Framework.Interpreter` to `show` of the underlying `PGS.SqlError`).
2. `fireFallbackHook` emits `L.logErrorV "JsonbFallbackTriggered"` with `{schema, table, error, action}` **before** retrying.
3. `KVM.incrementJsonbFallbackMetric` bumps the new `kv_jsonb_fallback_counter{schema, model}` — same `KVMetricCfg` / `L.getOption` dispatch as `incrementRedisCallMetric`, gated by `KV_METRIC_ENABLED`.
4. `findAllSqlJsonb` runs `SELECT to_jsonb(t.*) FROM "<schema>"."<table>" t WHERE <renderWhere>` and decodes each row via the table's `FromJSON`.
5. **Top-level row JSON is normalised** before decode (nested user payload — JSONB columns, text[] arrays — stays byte-identical):
   - keys rewritten `snake_case → camelCase` for `mkTableInstances`-generated `genericParseJSON defaultOptions` instances
   - bytea `"\xdeadbeef"` → `"deadbeef"` so `DbHash`-style `decodeHex` FromJSON accepts the value
   - `TEXT` columns holding `mkBeamInstancesForJSON`-serialised sum-types are parsed and substituted (only when the parse yields an Object or Array)
6. If decode still fails, the **original** DBError surfaces — no silent corruption.

## Type-coverage matrix (vs nammayatri shared-kernel)

| Type | Storage | Fallback |
|---|---|---|
| Simple (`Text`, `Bool`, `Int`, `Double`, `Maybe X`), `UTCTime`, `Maybe [Text]`, `Maybe Aeson.Value`, varchar enums via `mkBeamInstancesForEnum`, `HighPrecMoney` | varchar / int / float / timestamptz / jsonb / text[] | ✅ works |
| `DbHash` / `EncryptedField` | bytea | ✅ works (via `\x`-prefix strip) |
| `mkBeamInstancesForJSON` sum-types (BoothCharge, ReturnFee, FlowStatus, Translations, …) | TEXT containing JSON | ✅ works (via JSON-text unwrap) |
| Required column dropped from DB | n/a | ⚠️ original DBError surfaces — loud failure, no corruption |

## Test plan

- [x] `cabal build all` clean
- [x] Live integration test against real `atlas_driver_offer_bpp.person`: **19/19 cases pass, stable across multiple runs**:
  - drop `Maybe Text` (description / last_name) → fallback ok
  - drop `text[]` (tags) → fallback ok
  - drop `jsonb` (metadata) → fallback ok
  - drop `bytea` modeled via DbHash-mirror `HexBlob` → fallback ok
  - drop text-storing-JSON sum type (VehiclePref, `mkBeamInstancesForJSON` shape) → fallback ok
  - drop required column (first_name) → loud failure, original DBError preserved
- [ ] Bump `nammayatri/shared-kernel/flake.lock` once merged
- [ ] Bump `nammayatri/Backend/flake.lock`
- [ ] Prometheus alert: `rate(kv_jsonb_fallback_counter[5m]) > 0` (paging when ANY table triggers the fallback indicates schema/binary drift)

## Files

- `src/EulerHS/JsonbFallback.hs` — new module
- `src/EulerHS/CachedSqlDBQuery.hs` — `findAllSql` / `findOneSql` 42703 dispatch + constraint propagation through `findOne`/`findAll`/`deleteAllSqlMySQL`/`deleteAllMySQL`
- `src/EulerHS/KVConnector/Metrics.hs` — new `jsonbFallback` field on `KVMetricHandler`, `kv_jsonb_fallback_counter`, `incrementJsonbFallbackMetric`
- `src/EulerHS/KVConnector/Flow.hs` — constraint added to `findAllWithKVConnector`, `updateAllWithKVConnector`, `updateAllReturningWithKVConnector`, `deleteAllReturningWithKVConnector`
- `euler-hs.cabal` — exposes `EulerHS.JsonbFallback`, adds `executable jsonb-live-test`
- `test-jsonb-live/Main.hs` — live integration test runner

## Rollout

`euler-hs` (this PR) → `shared-kernel` flake.lock bump → `Backend` flake.lock bump. No code changes downstream.