### PR TITLE
[feat]: Add histogram metric for secondary key element count

### DIFF
--- a/src/EulerHS/KVConnector/Metrics.hs
+++ b/src/EulerHS/KVConnector/Metrics.hs
@@ -34,7 +34,8 @@ data KVMetricHandler = KVMetricHandler
     compressionLatency :: (Text, Text, Text, NominalDiffTime) -> IO (),
     handlerLatency :: (Text, Text, Double, Text, Text) -> IO (),
     kvHitMiss :: (Text, Text, KVFindResult) -> IO (),
-    jsonbFallback :: (Text, Text, Text) -> IO ()
+    jsonbFallback :: (Text, Text, Text) -> IO (),
+    secondaryKeyElements :: (Text, Text, Text, Int) -> IO ()
   }
 
 data KVFindResult = KVHit | MissInKV | MissInDB
@@ -78,6 +79,10 @@ mkKVMetricHandler = do
       ( \case
           (schema, model, _err) ->
             inc (metrics </> #kv_jsonb_fallback_counter) schema model
+      )
+      ( \case
+          (model, field, cluster, count) ->
+            observe (metrics </> #kvRedis_secondary_key_elements) (fromIntegral count) model field cluster
       )
 
 kv_compression_latency_observer =
@@ -167,6 +172,13 @@ kv_jsonb_fallback_counter =
     .& lbl @"model" @Text
     .& build
 
+kvRedis_secondary_key_elements =
+  histogram #kvRedis_secondary_key_elements
+    .& lbl @"model" @Text
+    .& lbl @"field" @Text
+    .& lbl @"cluster" @Text
+    .& build
+
 collectionLock =
   kv_sql_error_counter
     .> kvRedis_soft_db_limit_exceeded
@@ -177,6 +189,7 @@ collectionLock =
     .> kv_miss_in_kv_counter
     .> kv_miss_in_db_counter
     .> kv_jsonb_fallback_counter
+    .> kvRedis_secondary_key_elements
     .> MNil
 
 kv_handler_latency_observe =
@@ -265,3 +278,10 @@ withKVLatencyMetric handler model redisCluster action = do
   let totalLatency = fromIntegral (endTime - startTime)
   incrementKVHandlerLatencyMetric handler model totalLatency redisCluster
   pure result
+
+observeSecondaryKeyElements :: (HasCallStack, L.MonadFlow m) => Text -> Text -> Text -> Int -> m ()
+observeSecondaryKeyElements model field cluster count = when isKVMetricEnabled $ do
+  env <- L.getOption KVMetricCfg
+  case env of
+    Just val -> L.runIO $ secondaryKeyElements val (model, field, cluster, count)
+    Nothing -> pure ()

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -32,7 +32,7 @@ import qualified Database.Beam.Schema.Tables as B
 import qualified Database.Redis as DR
 import EulerHS.KVConnector.Encoding ()
 import qualified EulerHS.KVConnector.Encoding as Encoding
-import EulerHS.KVConnector.Metrics (KVMetric (..), incrementMetric)
+import EulerHS.KVConnector.Metrics (KVMetric (..), incrementMetric, observeSecondaryKeyElements)
 import EulerHS.KVConnector.Types
   ( DBCommandVersion (..),
     DBLogEntry (..),
@@ -688,6 +688,7 @@ getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = 
           case primaryRes of
             Left e -> pure $ Left $ RedisError $ (show e <> " for key: " <> show constructedKey)
             Right primaryKeys -> do
+              observeSecondaryKeyElements modelName k "primaryCluster" (length primaryKeys)
               -- If secondary Redis is enabled, also check it and merge results
               if meshCfg.secondaryRedisEnabled && meshCfg.meshEnabled
                 then do
@@ -695,6 +696,7 @@ getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = 
                   case secondaryRes of
                     Left e -> pure $ Left $ RedisError $ (show e <> " for secondary key: " <> show constructedKey)
                     Right secondaryKeys -> do
+                      observeSecondaryKeyElements modelName k "secondaryCluster" (length secondaryKeys)
                       -- Merge primary keys from both Redis instances (union)
                       let mergedKeys = mkUniq (primaryKeys ++ secondaryKeys)
                       pure $ Right $ Just mergedKeys


### PR DESCRIPTION
## Summary
- Adds a new histogram metric `kvRedis_secondary_key_elements` that records the number of members (primary keys) returned by each secondary-key `smembers` lookup, enabling alerts when a key's element count exceeds a configurable threshold.
- Recorded at both the primary and secondary Redis lookups in `getPrimaryKeyFromFieldAndValueHelper`, tagged by `cluster` (`primaryCluster` / `secondaryCluster`).
- Labels: `model` (table name), `field` (secondary key field), `cluster`. Element count is the observed value (bounded label cardinality).

## Details
- `src/EulerHS/KVConnector/Metrics.hs`
  - New histogram `kvRedis_secondary_key_elements`.
  - New `secondaryKeyElements` field on `KVMetricHandler` + closure in `mkKVMetricHandler`.
  - Registered in `collectionLock`.
  - New public helper `observeSecondaryKeyElements` (gated on `isKVMetricEnabled` + `KVMetricCfg`, consistent with existing helpers).
- `src/EulerHS/KVConnector/Utils.hs`
  - Records element count after each `smembers` (primary and secondary Redis).

## Alerting
Threshold lives in the Prometheus alert, not code, e.g.:
```promql
histogram_quantile(0.99, sum by (le, model, field) (rate(kvRedis_secondary_key_elements_bucket[5m]))) > 1000
```

Prerequisites (same as existing KV metrics): `KV_METRIC_ENABLED=True` and `KVMetricCfg` option set at startup.

## Test plan
- [x] `nix develop --command cabal build` compiles cleanly (all 52 modules, no errors)
- [ ] Verify metric appears in Prometheus scrape with `KV_METRIC_ENABLED=True`
- [ ] Confirm element counts are recorded for a secondary-key lookup on both clusters