### PR TITLE
feat: export GFieldNames from EulerHS.JsonbFallback

### DIFF
--- a/src/EulerHS/JsonbFallback.hs
+++ b/src/EulerHS/JsonbFallback.hs
@@ -19,6 +19,7 @@
 -- 'TryJsonbFallback' typeclass — external callers need no source changes.
 module EulerHS.JsonbFallback
   ( TryJsonbFallback (..),
+    GFieldNames,
     findAllSqlJsonb,
     findOneSqlJsonb,
     fireFallbackHook,


### PR DESCRIPTION
## Summary

Exports the `GFieldNames` typeclass from `EulerHS.JsonbFallback` so that downstream consumers (shared-kernel) can name it in their constraint synonyms.

## Why

The `OVERLAPPING TryJsonbFallback BP.Pg BP.Postgres` instance carries a `GFieldNames (Rep (table Identity))` constraint (added in the mkTableInstancesWithTModifier override-handling work). shared-kernel's KV-connector wrappers (`findAllInternal` / `updateInternal` / `deleteInternal` in `Kernel.Beam.Functions`) call the KV functions at **concrete** `Postgres` types, which forces GHC to resolve that OVERLAPPING instance and propagates its `GFieldNames` constraint up into shared-kernel's `BeamTable` synonym.

Currently `GFieldNames` is not exported, so shared-kernel cannot satisfy / name the constraint and fails to compile:

```
src/Kernel/Beam/Functions.hs:661:13: error:
    • Could not deduce (EulerHS.JsonbFallback.GFieldNames
                          (GHC.Generics.Rep (table Identity)))
        arising from a use of ‘KV.findAllWithKVConnector’
```

## What changes

One line — add `GFieldNames` to the module export list. No new instances, **no Template Haskell**. `GFieldNames` is a structural GHC.Generics class (`U1` / `M1 S` / `:*:` / `M1 D` / `M1 C`) that resolves automatically for every beam table's `Rep`. `Generic (table Identity)` is already derived on every beam table.

## Downstream follow-up (shared-kernel)

After this merges + flake.lock bump, shared-kernel adds one line to its `BeamTable` synonym:

```haskell
import EulerHS.JsonbFallback (GFieldNames)
import GHC.Generics (Rep)
-- in BeamTable:
GFieldNames (Rep (table Identity)),
```

Auto-satisfied for all ~600 beam tables; no per-table changes.

## Test plan

- [x] `cabal build all` clean
- [x] `cabal run jsonb-live-test` 38/38
- [x] pre-commit treefmt hook passes