### PR TITLE
feat(kv): sorted-set secondary indexes (ZSET) with per-table rollout config

### DIFF
--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          euler-hs
-version:       3.0.0
+version:       2.13.0.4
 synopsis:      The Flow framework for Euler.
 description:
 homepage:      https://github.com/juspay/euler-hs
@@ -201,21 +201,22 @@ flag enable-tests
   description: Enable building the opt-in / infra-heavy suites (language, jsonb).
   default: False
 
--- The one command: `cabal test`.
+-- The one command: `cabal run tests`.
 -- Self-managing: checks Postgres + Redis are up (prints how to start them if
 -- not), auto-creates the euler_sorted_test DB, and each suite cleans its own PG
--- rows + Redis keys. Runs kv-live + encoding + recache + jsonb + db + extra.
+-- rows + Redis keys. Runs kv-live + sorted-set (all 3 phases) + db + extra.
 -- Plain `cabal build` does NOT build this (or any test-suite) — only the library.
 test-suite tests
   import:         common-lang
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
-  hs-source-dirs: test/suite test/kv-live test/db test/extra test/jsonb-live
+  hs-source-dirs: test/suite test/kv-live test/sorted-set-live test/db test/extra test/jsonb-live
   other-modules:
     EncodingTests
     KvConnectorTH
     Schema
     KvLiveTests
+    SortedSetTests
     JsonbLiveTests
     Options
     SQLDB.TestData.Connections

--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -24,6 +24,8 @@ module EulerHS.KVConnector.Flow
     findAllWithKVAndConditionalDBInternal,
     findOneFromKvRedis,
     findAllFromKvRedis,
+    createInRedis,
+    maintainSecondaryIndexesOnWrite,
   )
 where
 
@@ -54,7 +56,7 @@ import EulerHS.KVConnector.Helper.Utils
 import EulerHS.KVConnector.InMemConfig.Flow (fetchRowFromDBAndAlterImc, pushToInMemConfigStream, searchInMemoryCache)
 import EulerHS.KVConnector.InMemConfig.Types (ImcStreamCommand (..))
 import qualified EulerHS.KVConnector.Metrics as Metrics
-import EulerHS.KVConnector.Types (DBCommandVersion (..), KVConnector (..), MeshConfig (..), MeshError (..), MeshMeta (..), MeshResult, SecondaryKey (..), Source (..), TableMappings (..), keyMap, tableName)
+import EulerHS.KVConnector.Types (DBCommandVersion (..), KVConnector (..), MeshConfig (..), MeshError (..), MeshMeta (..), MeshResult, SecondaryKey (..), SortedIndexMode (..), Source (..), TableMappings (..), keyMap, tableName)
 import EulerHS.KVConnector.Utils
 import EulerHS.KVDB.Types (KVDBReply)
 import qualified EulerHS.Language as L
@@ -159,15 +161,8 @@ createKV meshCfg value = do
           then do getCreateQueryWithCompression (getTableName @(table Identity)) (pKeyText <> shard) time meshCfg.meshDBName val (getTableMappings @(table Identity)) meshCfg.forceDrainToDB
           else do pure $ BSL.toStrict $ A.encode $ getCreateQuery (getTableName @(table Identity)) (pKeyText <> shard) time meshCfg.meshDBName val (getTableMappings @(table Identity)) meshCfg.forceDrainToDB
 
-      revMappingRes <-
-        mapM
-          ( \secIdx -> do
-              let sKey = fromString . T.unpack $ secIdx
-              _ <- L.runKVDB meshCfg.kvRedis $ L.sadd sKey [pKey]
-              L.runKVDB meshCfg.kvRedis $ L.expire sKey meshCfg.redisTtl
-          )
-          $ getSecondaryLookupKeys meshCfg.redisKeyPrefix val
-      case foldEither revMappingRes of
+      revMappingRes <- maintainSecondaryIndexesOnWrite meshCfg meshCfg.kvRedis pKey val
+      case revMappingRes of
         Left err -> pure $ Left $ RedisError (show err <> "Primary key => " <> show pKey <> " Secondary key => " <> show (getSecondaryLookupKeys meshCfg.redisKeyPrefix val) <> " in createKV")
         Right _ -> do
           kvRes <- L.runKVDB meshCfg.kvRedis $
@@ -199,15 +194,8 @@ createInRedis meshCfg val = do
   let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix val
       shard = getShardedHashTag meshCfg.tableShardModRange pKeyText
       pKey = fromString . T.unpack $ pKeyText <> shard
-  revMappingRes <-
-    mapM
-      ( \secIdx -> do
-          let sKey = fromString . T.unpack $ secIdx
-          _ <- L.runKVDB meshCfg.kvRedis $ L.sadd sKey [pKey]
-          L.runKVDB meshCfg.kvRedis $ L.expire sKey meshCfg.redisTtl
-      )
-      $ getSecondaryLookupKeys meshCfg.redisKeyPrefix val
-  case foldEither revMappingRes of
+  revMappingRes <- maintainSecondaryIndexesOnWrite meshCfg meshCfg.kvRedis pKey val
+  case revMappingRes of
     Left err -> pure $ Left $ RedisError (show err <> "Primary key => " <> show pKey <> " Secondary key => " <> show (getSecondaryLookupKeys meshCfg.redisKeyPrefix val))
     Right _ -> do
       kvRes <-
@@ -217,6 +205,41 @@ createInRedis meshCfg val = do
       case kvRes of
         Right _ -> pure $ Right val
         Left err -> pure $ Left (RedisError (show err <> "Primary key => " <> show pKey <> " Secondary key => " <> show (getSecondaryLookupKeys meshCfg.redisKeyPrefix val)))
+
+-- | Maintain a row's secondary indexes after a create / recache, honouring the
+--   sorted-index rollout phase ('sortedIndexMode'):
+--     * SET   (SADD + EXPIRE)        when 'shouldWriteSet'
+--     * ZSET  (ZADD score + EXPIRE)  when 'shouldWriteZSet' and the row has a score
+--   For non-sorted tables this collapses to exactly the legacy SADD+EXPIRE behaviour.
+maintainSecondaryIndexesOnWrite ::
+  forall table m.
+  (KVConnector (table Identity), L.MonadFlow m) =>
+  MeshConfig ->
+  Text ->
+  ByteString ->
+  table Identity ->
+  m (Either KVDBReply ())
+maintainSecondaryIndexesOnWrite meshCfg redisConn pKey val = do
+  let tableIsSorted = isSortedTable @table
+      mbScore = rowSortScore val
+      setKeys = getSecondaryLookupKeys meshCfg.redisKeyPrefix val
+  fmap (void . foldEither . concat) $
+    forM setKeys $ \sk -> do
+      setOps <-
+        if shouldWriteSet meshCfg.sortedIndexMode tableIsSorted
+          then do
+            r1 <- L.runKVDB redisConn $ L.sadd (fromString $ T.unpack sk) [pKey]
+            r2 <- L.runKVDB redisConn $ L.expire (fromString $ T.unpack sk) meshCfg.redisTtl
+            pure [void r1, void r2]
+          else pure []
+      zOps <- case (shouldWriteZSet meshCfg.sortedIndexMode tableIsSorted, mbScore) of
+        (True, Just score) -> do
+          let zk = fromString $ T.unpack $ toZSetKey sk
+          r3 <- L.runKVDB redisConn $ L.zadd zk [(score, pKey)]
+          r4 <- L.runKVDB redisConn $ L.expire zk meshCfg.redisTtl
+          pure [void r3, void r4]
+        _ -> pure []
+      pure (setOps ++ zOps)
 
 ---------------- Update -----------------
 
@@ -555,6 +578,8 @@ updateObjectRedis meshCfg redisConn updVals setClauses addPrimaryKeyToWhereClaus
           shard = getShardedHashTag meshCfg.tableShardModRange pKeyText
           pKey = fromString . T.unpack $ pKeyText <> shard
       let tName = tableName @(table Identity)
+          tableIsSorted = isSortedTable @table
+          mbScore = rowSortScore table
           updValsMap = HM.fromList (map (\p -> (fst p, True)) updVals)
           (modifiedSkeysOld, unModifiedSkeys) =
             applyFPair (map (getSortedKeyAndValue tName)) $
@@ -566,24 +591,47 @@ updateObjectRedis meshCfg redisConn updVals setClauses addPrimaryKeyToWhereClaus
       mapRight (const table)
         <$> runExceptT
           ( do
-              mapM_ (ExceptT . resetTTL) unModifiedSkeys
-              mapM_ (ExceptT . deletePkeyFromSkey pKey) modifiedSkeysOld
-              mapM_ (ExceptT . addPkeyToSkey pKey) modifiedSkeysNew
+              mapM_ (ExceptT . resetTTL pKey tableIsSorted mbScore) unModifiedSkeys
+              mapM_ (ExceptT . deletePkeyFromSkey pKey tableIsSorted) modifiedSkeysOld
+              mapM_ (ExceptT . addPkeyToSkey pKey tableIsSorted mbScore) modifiedSkeysNew
           )
 
-    resetTTL Nothing = pure $ Right False
-    resetTTL (Just key) = do
-      x <- L.rExpire redisConn (fromString $ T.unpack key) meshCfg.redisTtl
-      pure $ mapLeft MRedisError x
+    -- Unmodified secondary keys: refresh SET TTL; for sorted tables also re-score the
+    -- member in the ZSET (the score column, e.g. updatedAt, moved on this update).
+    resetTTL :: ByteString -> Bool -> Maybe Double -> Maybe Text -> m (MeshResult ())
+    resetTTL _ _ _ Nothing = pure $ Right ()
+    resetTTL pKey tableIsSorted mbScore (Just key) = runExceptT $ do
+      when (shouldWriteSet meshCfg.sortedIndexMode tableIsSorted) $
+        void $ ExceptT $ mapLeft MRedisError <$> L.rExpire redisConn (fromString $ T.unpack key) meshCfg.redisTtl
+      case (shouldWriteZSet meshCfg.sortedIndexMode tableIsSorted, mbScore) of
+        (True, Just score) -> do
+          let zk = fromString $ T.unpack $ toZSetKey key
+          void $ ExceptT $ mapLeft MRedisError <$> L.runKVDB redisConn (L.zadd zk [(score, pKey)])
+          void $ ExceptT $ mapLeft MRedisError <$> L.runKVDB redisConn (L.expire zk meshCfg.redisTtl)
+        _ -> pure ()
 
-    deletePkeyFromSkey _ Nothing = pure $ Right 0
-    deletePkeyFromSkey pKey (Just key) = mapLeft MRedisError <$> L.sRemB redisConn (fromString $ T.unpack key) [pKey]
+    -- Secondary key value changed: drop pkey from the OLD index (SET and/or ZSET).
+    deletePkeyFromSkey :: ByteString -> Bool -> Maybe Text -> m (MeshResult ())
+    deletePkeyFromSkey _ _ Nothing = pure $ Right ()
+    deletePkeyFromSkey pKey tableIsSorted (Just key) = runExceptT $ do
+      when (shouldWriteSet meshCfg.sortedIndexMode tableIsSorted) $
+        void $ ExceptT $ mapLeft MRedisError <$> L.sRemB redisConn (fromString $ T.unpack key) [pKey]
+      when (shouldWriteZSet meshCfg.sortedIndexMode tableIsSorted) $
+        void $ ExceptT $ mapLeft MRedisError <$> L.runKVDB redisConn (L.zrem (fromString $ T.unpack $ toZSetKey key) [pKey])
 
-    addPkeyToSkey :: ByteString -> Maybe Text -> m (MeshResult Bool)
-    addPkeyToSkey _ Nothing = pure $ Right False
-    addPkeyToSkey pKey (Just key) = do
-      _ <- L.rSadd redisConn (fromString $ T.unpack key) [pKey]
-      mapLeft MRedisError <$> L.rExpireB redisConn (fromString $ T.unpack key) meshCfg.redisTtl
+    -- Secondary key value changed: add pkey to the NEW index (SET and/or ZSET).
+    addPkeyToSkey :: ByteString -> Bool -> Maybe Double -> Maybe Text -> m (MeshResult ())
+    addPkeyToSkey _ _ _ Nothing = pure $ Right ()
+    addPkeyToSkey pKey tableIsSorted mbScore (Just key) = runExceptT $ do
+      when (shouldWriteSet meshCfg.sortedIndexMode tableIsSorted) $ do
+        _ <- ExceptT $ mapLeft MRedisError <$> L.rSadd redisConn (fromString $ T.unpack key) [pKey]
+        void $ ExceptT $ mapLeft MRedisError <$> L.rExpireB redisConn (fromString $ T.unpack key) meshCfg.redisTtl
+      case (shouldWriteZSet meshCfg.sortedIndexMode tableIsSorted, mbScore) of
+        (True, Just score) -> do
+          let zk = fromString $ T.unpack $ toZSetKey key
+          _ <- ExceptT $ mapLeft MRedisError <$> L.runKVDB redisConn (L.zadd zk [(score, pKey)])
+          void $ ExceptT $ mapLeft MRedisError <$> L.runKVDB redisConn (L.expire zk meshCfg.redisTtl)
+        _ -> pure ()
 
     getSortedKeyAndValue :: Text -> [(Text, Text)] -> Maybe Text
     getSortedKeyAndValue tName kvTup = do
@@ -1098,7 +1146,7 @@ findOneFromRedis meshCfg whereClause = do
       clusterName = if meshCfg.kvRedis == meshCfg.kvRedisSecondary then "secondaryCluster" else "primaryCluster"
 
   Metrics.withKVLatencyMetric "REDIS_FIND_ONE" modelName clusterName $ do
-    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinationsFiltered
+    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg (shouldReadZSet meshCfg.sortedIndexMode (isSortedTable @table)) keyHashMap) andCombinationsFiltered
     result <- case foldEither eitherKeyRes of
       Right keyRes -> do
         let lenKeyRes = lengthOfLists keyRes
@@ -1154,6 +1202,70 @@ findOneFromDB dbConf whereClause = do
 compareCols :: (Ord value) => (table Identity -> value) -> Bool -> table Identity -> table Identity -> Ordering
 compareCols col isAsc r1 r2 = if isAsc then compare (col r1) (col r2) else compare (col r2) (col r1)
 
+-- | Bounded ZSET LIMIT/OFFSET pushdown for 'findAllWithOptionsHelper'.
+--   Returns @Just result@ only when ALL of these hold (else 'Nothing' → safe fallback):
+--     * the table opted into sorted indexes ('isSortedTable') and phase is 'ZSetOnly';
+--     * single-cluster (multi-cloud falls back to the correct merge path);
+--     * a LIMIT is given and @orderBy@'s column == the ZSET score column;
+--     * the WHERE maps to exactly ONE secondary index that fully covers it.
+--   Even when eligible, if any fetched pkey's row blob has expired (TTL skew vs the
+--   ZSET member) we fall back so a bounded read can never under-deliver.
+tryZSetOptionsPushdown ::
+  forall be table m.
+  ( HasCallStack,
+    Model be table,
+    MeshMeta be table,
+    KVConnector (table Identity),
+    Serialize.Serialize (table Identity),
+    FromJSON (table Identity),
+    B.Beamable table,
+    L.MonadFlow m
+  ) =>
+  MeshConfig ->
+  Where be table ->
+  Maybe (OrderBy table) ->
+  Maybe Int ->
+  Maybe Int ->
+  m (Maybe (MeshResult [table Identity]))
+tryZSetOptionsPushdown meshCfg whereClause mbOrderBy mbLimit mbOffset
+  | meshCfg.kvHardKilled = pure Nothing
+  | not (isSortedTable @table) = pure Nothing
+  | meshCfg.sortedIndexMode /= ZSetOnly = pure Nothing
+  | meshCfg.secondaryRedisEnabled && meshCfg.meshEnabled = pure Nothing
+  | otherwise = case (mbOrderBy, mbLimit) of
+    (Just ob, Just limit)
+      | sortScoreColumn @(table Identity) == Just (orderByColumnName @be ob) ->
+        case singleCoveringZKey @be meshCfg whereClause of
+          Nothing -> pure Nothing
+          Just zKeyText -> do
+            let offset = fromIntegral (fromMaybe 0 mbOffset) :: Integer
+                count = fromIntegral limit :: Integer
+                zk = fromString $ T.unpack zKeyText
+                isDesc = case ob of Desc _ -> True; Asc _ -> False
+                posInf = 1 / 0 :: Double
+                negInf = negate posInf
+            pkeysRes <-
+              if isDesc
+                then L.runKVDB meshCfg.kvRedis $ L.zrevrangebyscorewithlimit zk posInf negInf offset count
+                else L.runKVDB meshCfg.kvRedis $ L.zrangebyscorewithlimit zk negInf posInf offset count
+            case pkeysRes of
+              Left _ -> pure Nothing -- redis hiccup → safe fallback
+              Right pkeys
+                -- ZSET members are unique by construction, so no de-dup here; crucially we
+                -- must NOT reorder (the score order from Z(REV)RANGE is the result order).
+                | null pkeys -> pure Nothing -- empty window: zKey may have TTL-expired → let DB confirm
+                | otherwise -> do
+                  rowsRes <- getDataFromPKeysRedis meshCfg.kvRedis pkeys
+                  case rowsRes of
+                    Left _ -> pure Nothing
+                    Right (liveRows, _deadRows) ->
+                      -- every requested pkey resolved to a LIVE row ⇒ window complete & ordered.
+                      -- otherwise some row blob expired ⇒ fall back so we never under-deliver.
+                      if length liveRows == length pkeys
+                        then pure $ Just $ Right $ findAllMatching whereClause liveRows
+                        else pure Nothing
+    _ -> pure Nothing
+
 findAllWithOptionsHelper ::
   forall be table beM m.
   ( HasCallStack,
@@ -1177,6 +1289,34 @@ findAllWithOptionsHelper ::
   Maybe Int ->
   m (MeshResult [table Identity])
 findAllWithOptionsHelper dbConf meshCfg whereClause orderBy mbLimit mbOffset = do
+  zsetFastPath <- tryZSetOptionsPushdown meshCfg whereClause orderBy mbLimit mbOffset
+  case zsetFastPath of
+    Just zsetResult -> pure zsetResult
+    Nothing -> findAllWithOptionsHelperFallback dbConf meshCfg whereClause orderBy mbLimit mbOffset
+
+findAllWithOptionsHelperFallback ::
+  forall be table beM m.
+  ( HasCallStack,
+    BeamRuntime be beM,
+    Model be table,
+    MeshMeta be table,
+    KVConnector (table Identity),
+    Serialize.Serialize (table Identity),
+    Show (table Identity),
+    ToJSON (table Identity),
+    FromJSON (table Identity),
+    L.MonadFlow m,
+    B.HasQBuilder be,
+    BeamRunner beM
+  ) =>
+  DBConfig beM ->
+  MeshConfig ->
+  Where be table ->
+  Maybe (OrderBy table) ->
+  Maybe Int ->
+  Maybe Int ->
+  m (MeshResult [table Identity])
+findAllWithOptionsHelperFallback dbConf meshCfg whereClause orderBy mbLimit mbOffset = do
   let isDisabled = meshCfg.kvHardKilled
       modelName = tableName @(table Identity)
   if not isDisabled
@@ -1640,7 +1780,7 @@ redisFindAll meshCfg whereClause = do
       clusterName = if meshCfg.kvRedis == meshCfg.kvRedisSecondary then "secondaryCluster" else "primaryCluster"
 
   Metrics.withKVLatencyMetric "REDIS_FIND_ALL" modelName clusterName $ do
-    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinationsFiltered
+    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg (shouldReadZSet meshCfg.sortedIndexMode (isSortedTable @table)) keyHashMap) andCombinationsFiltered
     result <- case foldEither eitherKeyRes of
       Right keyRes -> do
         let allKeys = concat keyRes
@@ -1705,6 +1845,14 @@ deleteObjectRedis meshCfg redisConn addPrimaryKeyToWhereClause whereClause obj =
   case kvDbRes of
     Left err -> return . Left $ RedisError (show err <> " for key " <> show pKey <> "in DeleteObjectRedis")
     Right _ -> do
+      -- For sorted tables, remove the pkey from the ZSET indexes so deleted rows don't
+      -- occupy top-N slots in a bounded ZRANGE (the SET path relies on the dead
+      -- tombstone instead). Best-effort: a failed cleanup only leaves a stale member,
+      -- which the read-time live/dead filter + fast-path fallback still handle.
+      when (shouldWriteZSet meshCfg.sortedIndexMode (isSortedTable @table)) $
+        mapM_
+          (\zk -> void $ L.runKVDB redisConn $ L.zrem (fromString $ T.unpack zk) [pKey])
+          (getSecondaryLookupKeysZ meshCfg.redisKeyPrefix obj)
       when meshCfg.memcacheEnabled $ pushToInMemConfigStream meshCfg ImcDelete obj
       return $ Right obj
 
@@ -1728,19 +1876,10 @@ reCacheDBRows meshCfg dbRows = do
           let pKeyText = getLookupKeyByPKey meshCfg.redisKeyPrefix obj
               shard = getShardedHashTag meshCfg.tableShardModRange pKeyText
               pKey = fromString . T.unpack $ pKeyText <> shard
-          res <-
-            mapM
-              ( \secIdx -> do
-                  -- Recaching Skeys in redis
-                  let sKey = fromString . T.unpack $ secIdx
-                  res1 <- L.runKVDB meshCfg.kvRedis $ L.sadd sKey [pKey]
-                  case res1 of
-                    Left err -> return $ Left err
-                    Right _ ->
-                      L.runKVDB meshCfg.kvRedis $ L.expire sKey meshCfg.redisTtl
-              )
-              $ getSecondaryLookupKeys meshCfg.redisKeyPrefix obj
-          return $ sequence res
+          -- SADD/ZADD the secondary indexes per rollout phase; ([] :: [Bool]) keeps
+          -- the historic return shape ([[Bool]]) intact.
+          res <- maintainSecondaryIndexesOnWrite meshCfg meshCfg.kvRedis pKey obj
+          return $ fmap (const ([] :: [Bool])) res
       )
       dbRows
   return $ sequence reCacheRes

--- a/src/EulerHS/KVConnector/InMemConfig/Flow.hs
+++ b/src/EulerHS/KVConnector/InMemConfig/Flow.hs
@@ -307,7 +307,7 @@ searchInMemoryCache meshCfg dbConf whereClause = do
           keyHashMap = keyMap @(table Identity)
       eitherKeyRes <-
         if fetchFromRedis
-          then mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinations
+          then mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg (shouldReadZSet meshCfg.sortedIndexMode (isSortedTable @table)) keyHashMap) andCombinations
           else mapM (getPrimaryKeyInIMCFromFieldsAndValues modelName keyHashMap) andCombinations
       pure $ foldEither eitherKeyRes
 

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -22,7 +22,8 @@ import Data.Aeson.Types (Parser)
 import Data.Data (Data)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
-import Data.Time (UTCTime)
+import Data.Time (Day, LocalTime, UTCTime, localTimeToUTC, toModifiedJulianDay, utc)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import qualified Database.Beam as B
 import Database.Beam.Backend (BeamSqlBackend, HasSqlValueSyntax (sqlValueSyntax), autoSqlValueSyntax)
 import qualified Database.Beam.Backend.SQL as B
@@ -49,6 +50,41 @@ class KVConnector table where
   primaryKey :: table -> PrimaryKey
   secondaryKeys :: table -> [SecondaryKey]
   mkSQLObject :: table -> A.Value
+
+  -- | Sorted-secondary-index support.
+  --   'Nothing'  => secondary indexes are plain Redis SETs (default / legacy behaviour).
+  --   'Just f'   => secondary indexes are maintained as sorted sets (ZSET) and @f@
+  --                 extracts the score (epoch-millis / day-number) from a row.
+  --   Populated by the @enableKVPGWithSortKey@ codegen macro; hand-written and
+  --   non-sorted ('enableKVPG') instances inherit the 'Nothing' default, so this is
+  --   fully backward compatible.
+  sortScore :: Maybe (table -> Double)
+  sortScore = Nothing
+
+  -- | Name of the column the ZSET is scored by (e.g. @"updatedAt"@). Used by the read
+  --   path to verify a query's @orderBy@ matches the ZSET ordering before pushing the
+  --   LIMIT/OFFSET into Redis. 'Nothing' for non-sorted tables.
+  sortScoreColumn :: Maybe Text
+  sortScoreColumn = Nothing
+
+----------------------------------------------
+
+-- | Columns usable as a ZSET sort score must reduce to a monotonic 'Double'.
+--   v1 supports time columns only. Equal scores tie-break by member (pkey) in Redis,
+--   so ordering stays deterministic.
+class ToZScore a where
+  toZScore :: a -> Double
+
+-- epoch milliseconds (fits a ZSET score's 52-bit double mantissa; do NOT use micros)
+instance ToZScore UTCTime where
+  toZScore = (* 1000) . realToFrac . utcTimeToPOSIXSeconds
+
+-- treat LocalTime as UTC-naive for ordering purposes (consistent, not TZ-correct)
+instance ToZScore LocalTime where
+  toZScore = (* 1000) . realToFrac . utcTimeToPOSIXSeconds . localTimeToUTC utc
+
+instance ToZScore Day where
+  toZScore = fromIntegral . toModifiedJulianDay
 
 ----------------------------------------------
 
@@ -101,6 +137,17 @@ instance ToJSON MeshError where
 
 data QueryPath = KVPath | SQLPath
 
+-- | Rollout mode for sorted-secondary-indexes (ZSETs). Read from env
+--   @KV_SORTED_INDEX_MODE@ (see 'EulerHS.KVConnector.Utils.sortedIndexMode').
+--   Only affects tables that opted in via a non-'Nothing' 'sortScore'.
+--
+--   * 'SetOnly'   — legacy: secondary indexes are plain SETs only (default).
+--   * 'DualWrite' — write BOTH SET and ZSET; reads still use the (complete) SET.
+--                   Canary/warm-up phase: safe while old (SET-only) pods coexist.
+--   * 'ZSetOnly'  — write/read ZSET only. Enter only after full rollout + >=1 TTL soak.
+data SortedIndexMode = SetOnly | DualWrite | ZSetOnly
+  deriving (Generic, Eq, Show, A.ToJSON, A.FromJSON)
+
 data MeshConfig = MeshConfig
   { meshEnabled :: Bool,
     cerealEnabled :: Bool,
@@ -114,7 +161,12 @@ data MeshConfig = MeshConfig
     kvHardKilled :: Bool,
     tableShardModRange :: (Int, Int),
     redisKeyPrefix :: Text,
-    forceDrainToDB :: Bool
+    forceDrainToDB :: Bool,
+    -- | Sorted-secondary-index (ZSET) rollout phase for THIS table. Set per-table
+    --   in shared-kernel from the @Tables@ config (kv_configs), so the phase can be
+    --   flipped centrally without a redeploy. Defaults to 'SetOnly' (legacy / safe);
+    --   non-sorted tables ignore it.
+    sortedIndexMode :: SortedIndexMode
   }
   deriving (Generic, Eq, Show, A.ToJSON)
 

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -45,6 +45,7 @@ import EulerHS.KVConnector.Types
     Operation (..),
     PrimaryKey (..),
     SecondaryKey (..),
+    SortedIndexMode (..),
     Source (..),
   )
 import EulerHS.KVDB.Types (KVDBReply)
@@ -55,7 +56,7 @@ import EulerHS.SqlDB.Types (DBError (..), DBErrorType (..))
 import EulerHS.Types (ApiTag (..))
 import Juspay.Extra.Config (lookupEnvT)
 import Safe (atMay)
-import Sequelize (Clause (..), Model, Set (..), Term (..), Where, columnize, fromColumnar', modelTableName)
+import Sequelize (Clause (..), Model, OrderBy (..), Set (..), Term (..), Where, columnize, fromColumnar', modelTableName)
 import Sequelize.SQLObject (ToSQLObject (..))
 import System.Random (randomRIO)
 import Text.Casing (quietSnake)
@@ -321,6 +322,74 @@ secondaryKeysFiltered table = filter filterEmptyValues (secondaryKeys table)
   where
     filterEmptyValues :: SecondaryKey -> Bool
     filterEmptyValues (SKey sKeyPairs) = not $ any (\p -> snd p == "") sKeyPairs
+
+----------- Sorted-secondary-index (ZSET) helpers -----------
+
+-- | Reserved prefix marking a ZSET secondary index. Distinct from the SET key name
+--   so both can coexist during the @Dual@ rollout phase without Redis @WRONGTYPE@.
+zSetKeyMarker :: Text
+zSetKeyMarker = "Z::"
+
+-- | ZSET variant of a SET secondary-index key.
+toZSetKey :: Text -> Text
+toZSetKey = (zSetKeyMarker <>)
+
+-- | ZSET secondary-index keys for a row (mirrors 'getSecondaryLookupKeys').
+getSecondaryLookupKeysZ :: forall table. (KVConnector (table Identity)) => Text -> table Identity -> [Text]
+getSecondaryLookupKeysZ redisKeyPrefix table = map toZSetKey (getSecondaryLookupKeys redisKeyPrefix table)
+
+-- | 'True' iff this table opted into sorted secondary indexes (declared a 'sortScore').
+isSortedTable :: forall table. (KVConnector (table Identity)) => Bool
+isSortedTable = isJust (sortScore @(table Identity))
+
+-- | The ZSET score for a row, if the table is sorted.
+rowSortScore :: forall table. (KVConnector (table Identity)) => table Identity -> Maybe Double
+rowSortScore table = ($ table) <$> sortScore @(table Identity)
+
+-- | Should writes maintain the plain SET for this table in the given phase?
+--   (Always, unless we are in ZSetOnly for a sorted table.) The phase comes from
+--   'MeshConfig.sortedIndexMode' (set per-table in shared-kernel), NOT a global env.
+shouldWriteSet :: SortedIndexMode -> Bool -> Bool
+shouldWriteSet mode tableIsSorted = not (tableIsSorted && mode == ZSetOnly)
+
+-- | Should writes maintain the ZSET for this table in the given phase?
+shouldWriteZSet :: SortedIndexMode -> Bool -> Bool
+shouldWriteZSet mode tableIsSorted = tableIsSorted && mode /= SetOnly
+
+-- | Should reads resolve secondary keys from the ZSET (rather than the SET)?
+--   Only in ZSetOnly for a sorted table (in Dual the SET is still complete).
+shouldReadZSet :: SortedIndexMode -> Bool -> Bool
+shouldReadZSet mode tableIsSorted = tableIsSorted && mode == ZSetOnly
+
+-- | The beam field name an 'OrderBy' sorts on, e.g. @"updatedAt"@. Used to verify
+--   a query's ordering matches the ZSET's score column before LIMIT pushdown.
+orderByColumnName :: forall be table. (Model be table, MeshMeta be table) => OrderBy table -> Text
+orderByColumnName ob =
+  let dt = B.dbTableSettings (meshModelTableEntityDescriptor @table @be)
+   in case ob of
+        Asc column -> B._fieldName . fromColumnar' . column . columnize $ dt
+        Desc column -> B._fieldName . fromColumnar' . column . columnize $ dt
+
+-- | If a WHERE clause maps to exactly ONE secondary index that FULLY covers it
+--   (no residual in-memory predicate, no OR / In fan-out), return that index's ZSET
+--   key. This is the eligibility gate for bounded ZSET LIMIT pushdown — anything else
+--   returns 'Nothing' so the caller falls back to the safe path.
+singleCoveringZKey ::
+  forall be table.
+  (Model be table, MeshMeta be table, KVConnector (table Identity)) =>
+  MeshConfig ->
+  Where be table ->
+  Maybe Text
+singleCoveringZKey meshCfg whereClause =
+  case getFieldsAndValuesFromClause (meshModelTableEntityDescriptor @table @be) (And whereClause) of
+    [combo] ->
+      let sorted = sortBy (compare `on` fst) combo
+          fieldName = T.intercalate "_" (map fst sorted)
+          valuePart = T.intercalate "_" (map snd sorted)
+       in if HM.lookup fieldName (keyMap @(table Identity)) == Just False && not (any (T.null . snd) combo)
+            then Just $ toZSetKey (meshCfg.redisKeyPrefix <> tableName @(table Identity) <> "_" <> fieldName <> "_" <> valuePart)
+            else Nothing
+    _ -> Nothing
 
 applyFPair :: (t -> b) -> (t, t) -> (b, b)
 applyFPair f (x, y) = (f x, f y)
@@ -672,19 +741,29 @@ getFieldsAndValuesFromClause dt = \case
       A.Bool b -> T.pack $ show b
       A.Null -> T.pack ""
 
-getPrimaryKeyFromFieldsAndValues :: (L.MonadFlow m) => Text -> MeshConfig -> HM.HashMap Text Bool -> [(Text, Text)] -> m (MeshResult [ByteString])
-getPrimaryKeyFromFieldsAndValues _ _ _ [] = pure $ Right []
-getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = do
+-- | Resolve secondary/primary keys for a clause combination.
+--   @useZSet@ (caller passes 'shouldReadZSet') makes the secondary lookup read the
+--   ZSET index (@ZRANGE 0 -1@ → all members, behaviour-equivalent to @SMEMBERS@)
+--   instead of the SET. Primary-key resolution is unchanged.
+getPrimaryKeyFromFieldsAndValues :: (L.MonadFlow m) => Text -> MeshConfig -> Bool -> HM.HashMap Text Bool -> [(Text, Text)] -> m (MeshResult [ByteString])
+getPrimaryKeyFromFieldsAndValues _ _ _ _ [] = pure $ Right []
+getPrimaryKeyFromFieldsAndValues modelName meshCfg useZSet keyHashMap fieldsAndValues = do
   res <- foldEither <$> mapM getPrimaryKeyFromFieldAndValueHelper fieldsAndValues
   pure $ mapRight (intersectList . catMaybes) res
   where
+    -- read all members of a secondary index: ZRANGE (sorted) when on the ZSET path,
+    -- otherwise SMEMBERS. Both return the full member (pkey) list.
+    readSecondaryMembers conn setKey =
+      if useZSet
+        then L.runKVDB conn $ L.zrange (fromString $ T.unpack $ toZSetKey setKey) 0 (-1)
+        else L.runKVDB conn $ L.smembers (fromString $ T.unpack setKey)
     getPrimaryKeyFromFieldAndValueHelper (k, v) = do
       let constructedKey = meshCfg.redisKeyPrefix <> modelName <> "_" <> k <> "_" <> v
       case HM.lookup k keyHashMap of
         Just True -> pure $ Right $ Just [fromString $ T.unpack (constructedKey <> getShardedHashTag meshCfg.tableShardModRange constructedKey)]
         Just False -> do
           -- Check primary Redis first
-          primaryRes <- L.runKVDB meshCfg.kvRedis $ L.smembers (fromString $ T.unpack constructedKey)
+          primaryRes <- readSecondaryMembers meshCfg.kvRedis constructedKey
           case primaryRes of
             Left e -> pure $ Left $ RedisError $ (show e <> " for key: " <> show constructedKey)
             Right primaryKeys -> do
@@ -692,15 +771,17 @@ getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = 
               -- If secondary Redis is enabled, also check it and merge results
               if meshCfg.secondaryRedisEnabled && meshCfg.meshEnabled
                 then do
-                  secondaryRes <- L.runKVDB meshCfg.kvRedisSecondary $ L.smembers (fromString $ T.unpack constructedKey)
+                  secondaryRes <- readSecondaryMembers meshCfg.kvRedisSecondary constructedKey
                   case secondaryRes of
                     Left e -> pure $ Left $ RedisError $ (show e <> " for secondary key: " <> show constructedKey)
                     Right secondaryKeys -> do
                       observeSecondaryKeyElements modelName k "secondaryCluster" (length secondaryKeys)
-                      -- Merge primary keys from both Redis instances (union)
+                      -- Merge primary keys from both Redis instances (union, de-duplicated)
                       let mergedKeys = mkUniq (primaryKeys ++ secondaryKeys)
                       pure $ Right $ Just mergedKeys
-                else pure $ Right $ Just primaryKeys
+                else -- de-duplicate SMEMBERS/ZRANGE members defensively (a pkey could be
+                -- present more than once across overlapping index reads)
+                  pure $ Right $ Just (mkUniq primaryKeys)
         _ -> pure $ Right Nothing
 
     intersectList (x : y : xs) = intersectList (intersect x y : xs)
@@ -766,6 +847,17 @@ isCachingDbFindEnabled = fromMaybe False $ readMaybe =<< lookupEnvT @String "IS_
 
 isPipeliningEnabled :: Bool
 isPipeliningEnabled = fromMaybe True $ readMaybe =<< lookupEnvT @String "enablePipelining"
+
+-- | Global DEFAULT rollout phase, read once from env @KV_SORTED_INDEX_MODE@ ∈
+--   {SET_ONLY (default), DUAL, ZSET_ONLY}. The per-table phase now lives in
+--   'MeshConfig.sortedIndexMode' (set in shared-kernel from the Tables config);
+--   shared-kernel uses THIS as the fallback when a table has no per-table override,
+--   so existing env-based deployments keep working during migration.
+defaultSortedIndexMode :: SortedIndexMode
+defaultSortedIndexMode = case lookupEnvT @String "KV_SORTED_INDEX_MODE" of
+  Just "DUAL" -> DualWrite
+  Just "ZSET_ONLY" -> ZSetOnly
+  _ -> SetOnly
 
 shouldLogFindDBCallLogs :: Bool
 shouldLogFindDBCallLogs = fromMaybe False $ readMaybe =<< lookupEnvT @String "IS_FIND_DB_LOGS_ENABLED"

--- a/src/EulerHS/KVDB/Interpreter.hs
+++ b/src/EulerHS/KVDB/Interpreter.hs
@@ -151,6 +151,8 @@ interpretKeyValueF runRedis (L.ZRangeByScore k minScore maxScore next) =
   fmap next $ runRedis $ R.zrangebyscore k minScore maxScore
 interpretKeyValueF runRedis (L.ZRangeByScoreWithLimit k minScore maxScore offset count next) =
   fmap next $ runRedis $ R.zrangebyscoreLimit k minScore maxScore offset count
+interpretKeyValueF runRedis (L.ZRevRangeByScoreWithLimit k maxScore minScore offset count next) =
+  fmap next $ runRedis $ R.zrevrangebyscoreLimit k maxScore minScore offset count
 interpretKeyValueF runRedis (L.ZRem k v next) =
   fmap next $ runRedis $ R.zrem k v
 interpretKeyValueF runRedis (L.ZRemRangeByScore k minScore maxScore next) =
@@ -258,6 +260,8 @@ interpretKeyValueTxF (L.ZRangeByScore k minScore maxScore next) =
   next <$> R.zrangebyscore k minScore maxScore
 interpretKeyValueTxF (L.ZRangeByScoreWithLimit k minScore maxScore offset count next) =
   next <$> R.zrangebyscoreLimit k minScore maxScore offset count
+interpretKeyValueTxF (L.ZRevRangeByScoreWithLimit k maxScore minScore offset count next) =
+  next <$> R.zrevrangebyscoreLimit k maxScore minScore offset count
 interpretKeyValueTxF (L.ZRem k v next) =
   next <$> R.zrem k v
 interpretKeyValueTxF (L.ZRemRangeByScore k minScore maxScore next) =

--- a/src/EulerHS/KVDB/Language.hs
+++ b/src/EulerHS/KVDB/Language.hs
@@ -95,6 +95,7 @@ module EulerHS.KVDB.Language
     zrange,
     zrangebyscore,
     zrangebyscorewithlimit,
+    zrevrangebyscorewithlimit,
     zrem,
     zremrangebyscore,
     zcard,
@@ -200,6 +201,7 @@ data KeyValueF f next where
   ZRange :: KVDBKey -> Integer -> Integer -> (f [ByteString] -> next) -> KeyValueF f next
   ZRangeByScore :: KVDBKey -> Double -> Double -> (f [ByteString] -> next) -> KeyValueF f next
   ZRangeByScoreWithLimit :: KVDBKey -> Double -> Double -> Integer -> Integer -> (f [ByteString] -> next) -> KeyValueF f next
+  ZRevRangeByScoreWithLimit :: KVDBKey -> Double -> Double -> Integer -> Integer -> (f [ByteString] -> next) -> KeyValueF f next
   ZRem :: KVDBKey -> [KVDBValue] -> (f Integer -> next) -> KeyValueF f next
   ZRemRangeByScore :: KVDBKey -> Double -> Double -> (f Integer -> next) -> KeyValueF f next
   ZCard :: KVDBKey -> (f Integer -> next) -> KeyValueF f next
@@ -237,6 +239,7 @@ instance Functor (KeyValueF f) where
   fmap f (ZRange k s1 s2 next) = ZRange k s1 s2 (f . next)
   fmap f (ZRangeByScore k s1 s2 next) = ZRangeByScore k s1 s2 (f . next)
   fmap f (ZRangeByScoreWithLimit k s1 s2 offset count next) = ZRangeByScoreWithLimit k s1 s2 offset count (f . next)
+  fmap f (ZRevRangeByScoreWithLimit k s1 s2 offset count next) = ZRevRangeByScoreWithLimit k s1 s2 offset count (f . next)
   fmap f (ZRem k v next) = ZRem k v (f . next)
   fmap f (ZRemRangeByScore k s1 s2 next) = ZRemRangeByScore k s1 s2 (f . next)
   fmap f (ZCard k next) = ZCard k (f . next)
@@ -423,6 +426,11 @@ zremrangebyscore key minScore maxScore = ExceptT $ liftFC $ KV $ ZRemRangeByScor
 
 zrangebyscorewithlimit :: KVDBKey -> Double -> Double -> Integer -> Integer -> KVDB [ByteString]
 zrangebyscorewithlimit key minScore maxScore offset count = ExceptT $ liftFC $ KV $ ZRangeByScoreWithLimit key minScore maxScore offset count id
+
+-- | Like 'zrangebyscorewithlimit' but ordered high-score to low-score (ZREVRANGEBYSCORE).
+-- Note: for ZREVRANGEBYSCORE the score bounds are passed max-then-min.
+zrevrangebyscorewithlimit :: KVDBKey -> Double -> Double -> Integer -> Integer -> KVDB [ByteString]
+zrevrangebyscorewithlimit key maxScore minScore offset count = ExceptT $ liftFC $ KV $ ZRevRangeByScoreWithLimit key maxScore minScore offset count id
 
 zcard :: KVDBKey -> KVDB Integer
 zcard key = ExceptT $ liftFC $ KV $ ZCard key id

--- a/test/kv-live/KvLiveTests.hs
+++ b/test/kv-live/KvLiveTests.hs
@@ -52,7 +52,7 @@ import EulerHS.KVConnector.Flow
     updateWithKVConnector,
     updateWoReturningWithKVConnector,
   )
-import EulerHS.KVConnector.Types (MeshConfig (..), MeshMeta (..), MeshResult, TermWrap)
+import EulerHS.KVConnector.Types (MeshConfig (..), MeshMeta (..), MeshResult, SortedIndexMode (..), TermWrap)
 import EulerHS.KVConnector.Utils (getPKeyWithShard)
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (id, note, putStrLn, show)
@@ -111,7 +111,8 @@ meshCfg =
       kvHardKilled = False,
       tableShardModRange = (0, 128),
       redisKeyPrefix = "",
-      forceDrainToDB = False
+      forceDrainToDB = False,
+      sortedIndexMode = SetOnly -- kv_live is a plain (non-sorted) table; mode is a no-op for it
     }
 
 -- Treat the secondary Redis as this pod's primary (used to seed the "other cloud").

--- a/test/language/KV/TestSchema/Mesh.hs
+++ b/test/language/KV/TestSchema/Mesh.hs
@@ -5,7 +5,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import EulerHS.KVConnector.Types (MeshConfig (..))
+import EulerHS.KVConnector.Types (MeshConfig (..), SortedIndexMode (..))
 import System.Environment (getEnvironment)
 import System.IO.Unsafe (unsafePerformIO)
 import Text.Read (readMaybe)
@@ -26,7 +26,8 @@ meshConfig =
       kvHardKilled = False,
       tableShardModRange = (0, 128),
       redisKeyPrefix = "",
-      forceDrainToDB = False
+      forceDrainToDB = False,
+      sortedIndexMode = SetOnly
     }
 
 dbMeshTrackerTables :: Set.Set Text

--- a/test/sorted-set-live/SortedSetTests.hs
+++ b/test/sorted-set-live/SortedSetTests.hs
@@ -1,0 +1,533 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-missing-methods -Wno-name-shadowing -Wno-unused-imports #-}
+
+-- =============================================================================
+-- Live, end-to-end tests for the sorted-secondary-index (ZSET) feature.
+--
+-- Exercises the REAL connector code (createWithKVConnector, findAllWithOptionsKVConnector,
+-- updateWithKVConnector, deleteWithKVConnector) against a real Postgres + Redis, plus the
+-- raw ZSET primitives and the multi-cloud union path.
+--
+-- Postgres only (matches production). Phase is read from KV_SORTED_INDEX_MODE and is fixed
+-- per process, so run once per phase:
+--
+--   <local postgres on 5432, db euler_sorted_test, table kv_sorted>
+--   redis-server --port 6379 ; redis-server --port 6380
+--   cabal run euler-hs:exe:sorted-set-live-test
+--   KV_SORTED_INDEX_MODE=DUAL      cabal run euler-hs:exe:sorted-set-live-test
+--   KV_SORTED_INDEX_MODE=ZSET_ONLY cabal run euler-hs:exe:sorted-set-live-test
+-- =============================================================================
+
+module SortedSetTests (runSortedSetTests) where
+
+import qualified Data.Aeson as A
+import qualified Data.HashMap.Strict as HM
+import Data.List (sort)
+import qualified Data.Serialize as Cereal
+import qualified Data.Text as T
+import Data.Time (UTCTime (..), addUTCTime, fromGregorian, secondsToDiffTime)
+import qualified Database.Beam as B
+import qualified Database.Beam.Postgres as BP
+import qualified Database.PostgreSQL.Simple as PGS
+import qualified EulerHS.Interpreters as I
+import EulerHS.KVConnector.Flow
+  ( createWithKVConnector,
+    deleteWithKVConnector,
+    findAllWithOptionsKVConnector,
+    updateWithKVConnector,
+  )
+import EulerHS.KVConnector.Types
+import EulerHS.KVConnector.Utils
+  ( getPKeyWithShard,
+    getPrimaryKeyFromFieldsAndValues,
+    getSecondaryLookupKeys,
+    defaultSortedIndexMode,
+    shouldReadZSet,
+    shouldWriteSet,
+    shouldWriteZSet,
+    toZSetKey,
+  )
+import qualified EulerHS.Language as L
+import EulerHS.Prelude hiding (id, putStrLn, show)
+import qualified EulerHS.Runtime as R
+import EulerHS.Types
+  ( DBConfig,
+    PoolConfig (..),
+    PostgresConfig (..),
+    mkPostgresPoolConfig,
+  )
+import qualified EulerHS.Types as T
+import Sequelize (Clause (..), ModelMeta (..), OrderBy (..), Set (..), Term (..), Where)
+import Prelude (Show (show), String, putStrLn)
+
+-- =============================================================================
+-- Table: kv_sorted (id pk, group_id secondary index, updated_at = ZSET score)
+-- =============================================================================
+
+data KVSortedT f = KVSortedT
+  { id :: B.C f Text,
+    groupId :: B.C f Text,
+    updatedAt :: B.C f UTCTime,
+    payload :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table KVSortedT where
+  data PrimaryKey KVSortedT f = KVSortedId (B.C f Text) deriving (Generic, B.Beamable)
+  primaryKey = KVSortedId . id
+
+type KVSorted = KVSortedT Identity
+
+deriving instance Show KVSorted
+
+deriving instance Eq KVSorted
+
+instance A.ToJSON KVSorted where toJSON = A.genericToJSON A.defaultOptions
+
+instance A.FromJSON KVSorted where parseJSON = A.genericParseJSON A.defaultOptions
+
+instance Cereal.Serialize KVSorted where
+  put = error "cereal disabled"
+  get = error "cereal disabled"
+
+-- SQL column names (snake_case) — used by ModelMeta for the actual Postgres query.
+kvSortedModSql :: KVSortedT (B.FieldModification (B.TableField KVSortedT))
+kvSortedModSql =
+  B.tableModification
+    { id = B.fieldNamed "id",
+      groupId = B.fieldNamed "group_id",
+      updatedAt = B.fieldNamed "updated_at",
+      payload = B.fieldNamed "payload"
+    }
+
+-- Haskell field names (camelCase) — used by MeshMeta for the KV/redis side, so it stays
+-- consistent with KVConnector.secondaryKeys and the row's genericToJSON keys. This mirrors
+-- how the codegen macro wires ModMesh (nameBase) vs the SQL Mod (quietSnake).
+kvSortedModMesh :: KVSortedT (B.FieldModification (B.TableField KVSortedT))
+kvSortedModMesh =
+  B.tableModification
+    { id = B.fieldNamed "id",
+      groupId = B.fieldNamed "groupId",
+      updatedAt = B.fieldNamed "updatedAt",
+      payload = B.fieldNamed "payload"
+    }
+
+instance ModelMeta KVSortedT where
+  modelFieldModification = kvSortedModSql
+  modelTableName = "kv_sorted"
+  modelSchemaName = Nothing
+
+instance MeshMeta BP.Postgres KVSortedT where
+  meshModelFieldModification = kvSortedModMesh
+  valueMapper = mempty
+  parseFieldAndGetClause _ _ = fail "parseFieldAndGetClause: not exercised by this test"
+  parseSetClause _ = fail "parseSetClause: not exercised by this test"
+
+instance KVConnector (KVSortedT Identity) where
+  tableName = "kvSorted"
+  keyMap = HM.fromList [("id", True), ("groupId", False)]
+  primaryKey r = PKey [("id", id r)]
+  secondaryKeys r = [SKey [("groupId", groupId r)]]
+  mkSQLObject = A.toJSON
+  sortScore = Just (\r -> toZScore (updatedAt r))
+  sortScoreColumn = Just "updatedAt"
+
+instance TableMappings (KVSortedT Identity) where
+  getTableName = "kv_sorted"
+  getTableMappings = []
+
+-- =============================================================================
+-- Config & helpers
+-- =============================================================================
+
+dbConf :: DBConfig BP.Pg
+dbConf =
+  mkPostgresPoolConfig
+    "sorted-live"
+    PostgresConfig
+      { connectHost = "localhost",
+        connectPort = 5432,
+        connectUser = "postgres",
+        connectPassword = "",
+        connectDatabase = "euler_sorted_test"
+      }
+    PoolConfig {stripes = 1, keepAlive = 10, resourcesPerStripe = 4}
+
+connName, connNameSecondary :: Text
+connName = "KVRedis"
+connNameSecondary = "KVRedisSecondary"
+
+redisCfg :: T.KVDBConfig
+redisCfg = T.mkKVDBConfig connName T.defaultKVDBConnConfig
+
+redisCfgSecondary :: T.KVDBConfig
+redisCfgSecondary = T.mkKVDBConfig connNameSecondary (T.defaultKVDBConnConfig {T.connectPort = 6380})
+
+-- The rollout phase under test. The connector reads it from MeshConfig.sortedIndexMode
+-- (NOT a global env), so we simply put it on the config. We pick it from the
+-- KV_SORTED_INDEX_MODE env here only to drive the 3 phases of this harness.
+mode :: SortedIndexMode
+mode = defaultSortedIndexMode
+
+meshCfg :: MeshConfig
+meshCfg =
+  MeshConfig
+    { meshEnabled = True,
+      cerealEnabled = False,
+      memcacheEnabled = False,
+      meshDBName = "ECRDB",
+      ecRedisDBStream = "db-sync-stream",
+      kvRedis = connName,
+      kvRedisSecondary = connName,
+      secondaryRedisEnabled = False,
+      redisTtl = 3600,
+      kvHardKilled = False,
+      tableShardModRange = (0, 128),
+      redisKeyPrefix = "",
+      forceDrainToDB = False,
+      sortedIndexMode = mode
+    }
+
+cfgPrimaryOnly, cfgSecondaryAsPrimary, cfgMultiCloud :: MeshConfig
+cfgPrimaryOnly = meshCfg {kvRedis = connName, secondaryRedisEnabled = False}
+cfgSecondaryAsPrimary = meshCfg {kvRedis = connNameSecondary, secondaryRedisEnabled = False}
+cfgMultiCloud = meshCfg {kvRedis = connName, kvRedisSecondary = connNameSecondary, secondaryRedisEnabled = True}
+
+baseTime :: UTCTime
+baseTime = UTCTime (fromGregorian 2026 1 1) (secondsToDiffTime 0)
+
+mkRow :: Text -> Text -> Integer -> KVSorted
+mkRow i g secs = KVSortedT {id = i, groupId = g, updatedAt = addUTCTime (fromIntegral secs) baseTime, payload = "p-" <> i}
+
+enc :: Text -> ByteString
+enc = encodeUtf8
+
+runFlow :: L.Flow a -> IO a
+runFlow flow =
+  R.withFlowRuntime Nothing $ \rt ->
+    I.runFlow rt $ do
+      _ <- L.initSqlDBConnection dbConf
+      _ <- L.initKVDBConnection redisCfg
+      _ <- L.initKVDBConnection redisCfgSecondary
+      flow
+
+runRaw :: Text -> IO ()
+runRaw sql = do
+  c <- PGS.connectPostgreSQL "host=localhost port=5432 user=postgres dbname=euler_sorted_test"
+  _ <- PGS.execute_ c (fromString (T.unpack sql))
+  PGS.close c
+
+cleanPg :: IO ()
+cleanPg = runRaw "DELETE FROM kv_sorted"
+
+-- Make a run hermetic: drop every key this test owns on BOTH clouds before starting.
+-- Only the test's own keyspace is touched (kvSorted_*, the Z:: sorted-index mirror, and the
+-- raw-primitive scratch key) — never a global FLUSH, so any other data on these Redis
+-- instances is left intact. Without this, a member written by a previous phase (TTL 1h) would
+-- linger and make a later phase observe an index entry it never wrote.
+flushTestKeys :: L.Flow ()
+flushTestKeys =
+  forM_ [connName, connNameSecondary] $ \conn ->
+    forM_ ["kvSorted*", "Z::kvSorted*", "live:zset:*"] $ \pat -> do
+      eks <- L.runKVDB conn $ L.rawRequest ["KEYS", enc pat]
+      case eks of
+        Right (ks :: [ByteString]) -> unless (null ks) . void . L.runKVDB conn $ L.del ks
+        Left _ -> pure ()
+
+check :: String -> Bool -> IO Bool
+check label ok = do
+  putStrLn $ "  " <> (if ok then "[PASS] " else "[FAIL] ") <> label
+  pure ok
+
+-- secondary SET key / ZSET key for a groupId value
+setKeyFor :: Text -> Text
+setKeyFor g = case getSecondaryLookupKeys "" (mkRow "x" g 0) of (k : _) -> k; [] -> ""
+
+zKeyFor :: Text -> Text
+zKeyFor = toZSetKey . setKeyFor
+
+-- exactly what the connector stores as the pkey/member (incl. shard hash-tag)
+pkOf :: KVSorted -> ByteString
+pkOf r = enc $ getPKeyWithShard r meshCfg.redisKeyPrefix meshCfg.tableShardModRange
+
+-- =============================================================================
+-- Tests
+-- =============================================================================
+
+-- | Run the sorted-secondary-index (ZSET) suite for the rollout phase given by
+--   the KV_SORTED_INDEX_MODE env var (read once, per-process). Returns True iff
+--   all assertions passed. Cleans its own PG rows + Redis keys.
+runSortedSetTests :: IO Bool
+runSortedSetTests = do
+  putStrLn $ "\n############################################################"
+  putStrLn $ "#  sorted-set-live  [phase=" <> show mode <> "]"
+  putStrLn $ "############################################################"
+  runFlow flushTestKeys -- hermetic: clear this test's keyspace on both clouds before starting
+  -- INDEPENDENT oracle: the SET/ZSET we EXPECT per rollout phase, hardcoded from
+  -- the rollout spec — NOT derived from shouldWriteSet/shouldWriteZSet (the
+  -- functions under test). This way a sign-flip in those functions is caught
+  -- instead of being masked by a self-referential expectation.
+  let (expectSet, expectZ) = case mode of
+        SetOnly -> (True, False) -- legacy: SET only
+        DualWrite -> (True, True) -- warm-up: write both
+        ZSetOnly -> (False, True) -- final: ZSET only
+
+  -- ---- 1. raw ZSET primitives (mode independent) -------------------------
+  putStrLn "\n[1] ZSET primitives (zadd/zrevrangebyscorewithlimit/zrangebyscorewithlimit/zrem/zrange/re-score)"
+  prim <- runFlow $ do
+    let k = enc "live:zset:prim"
+    _ <- L.runKVDB connName $ L.del [k]
+    _ <- L.runKVDB connName $ L.zadd k [(100, "a"), (200, "b"), (300, "c")]
+    d2 <- L.runKVDB connName $ L.zrevrangebyscorewithlimit k (1 / 0) (negate (1 / 0)) 0 2
+    a1 <- L.runKVDB connName $ L.zrangebyscorewithlimit k (negate (1 / 0)) (1 / 0) 1 1
+    _ <- L.runKVDB connName $ L.zrem k ["b"]
+    rem' <- L.runKVDB connName $ L.zrange k 0 (-1)
+    _ <- L.runKVDB connName $ L.zadd k [(50, "a")]
+    res' <- L.runKVDB connName $ L.zrange k 0 (-1)
+    _ <- L.runKVDB connName $ L.del [k]
+    pure (d2, a1, rem', res')
+  ok1 <- check "primitives" (prim == (Right ["c", "b"], Right ["b"], Right ["a", "c"], Right ["a", "c"]))
+
+  -- ---- 2. createWithKVConnector → membership per phase -------------------
+  putStrLn "\n[2] createWithKVConnector maintains SET/ZSET per phase"
+  cleanPg
+  (sm, zm) <- runFlow $ do
+    let row = mkRow "c1" "gC" 100
+    _ <- createWithKVConnector dbConf meshCfg row
+    s <- L.runKVDB connName $ L.smembers (enc (setKeyFor "gC"))
+    z <- L.runKVDB connName $ L.zrange (enc (zKeyFor "gC")) 0 (-1)
+    pure (s, z)
+  ok2a <- check ("SET membership == " <> show expectSet) (sm == Right [pkOf (mkRow "c1" "gC" 100) | expectSet])
+  ok2b <- check ("ZSET membership == " <> show expectZ) (zm == Right [pkOf (mkRow "c1" "gC" 100) | expectZ])
+
+  -- ---- 3. findAllWithOptionsKVConnector ordered + limited (KV hit) -------
+  putStrLn "\n[3] findAllWithOptions Desc updatedAt limit 2 (fast-path in ZSetOnly, in-mem sort otherwise)"
+  cleanPg
+  r3 <- runFlow $ do
+    forM_ [mkRow "f1" "gF" 100, mkRow "f2" "gF" 200, mkRow "f3" "gF" 300] (createWithKVConnector dbConf meshCfg)
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("gF" :: Text))] (Desc updatedAt) (Just 2) Nothing
+  ok3 <- check "top-2 by updatedAt desc == [f3, f2]" $ case r3 of
+    Right rows -> map id rows == ["f3", "f2"]
+    Left _ -> False
+
+  -- ---- 4. DB fallback: rows only in Postgres come back via the merge -----
+  putStrLn "\n[4] DB fallback — row only in Postgres (not in KV) is returned"
+  cleanPg
+  runRaw "INSERT INTO kv_sorted (id,group_id,updated_at,payload) VALUES ('db1','gDB','2026-02-01T00:00:00Z','only-in-pg')"
+  r4 <- runFlow $ findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("gDB" :: Text))] (Desc updatedAt) (Just 10) Nothing
+  ok4 <- check "DB-only row returned via fallback" $ case r4 of
+    Right rows -> map id rows == ["db1"]
+    Left _ -> False
+
+  -- ---- 5. update: changing the secondary value moves the index entry -----
+  putStrLn "\n[5] updateWithKVConnector moves pkey between secondary indexes"
+  cleanPg
+  (oldHas, newHas) <- runFlow $ do
+    let row = mkRow "u1" "gOld" 100
+    _ <- createWithKVConnector dbConf meshCfg row
+    _ <- updateWithKVConnector dbConf dbConf meshCfg [Set groupId ("gNew" :: Text)] [Is id (Eq ("u1" :: Text))]
+    let readK g =
+          if expectZ
+            then L.runKVDB connName $ L.zrange (enc (zKeyFor g)) 0 (-1)
+            else L.runKVDB connName $ L.smembers (enc (setKeyFor g))
+    o <- readK "gOld"
+    n <- readK "gNew"
+    pure (o, n)
+  let upk = pkOf (mkRow "u1" "gNew" 100)
+  ok5a <- check "old index no longer has pkey" (oldHas == Right [])
+  ok5b <- check "new index has pkey" (newHas == Right [upk])
+
+  -- ---- 6. delete: ZREM / SREM removes the pkey from the index ------------
+  putStrLn "\n[6] deleteWithKVConnector removes pkey from the index"
+  cleanPg
+  afterDel <- runFlow $ do
+    let row = mkRow "d1" "gDel" 100
+    _ <- createWithKVConnector dbConf meshCfg row
+    _ <- deleteWithKVConnector dbConf meshCfg [Is id (Eq ("d1" :: Text))]
+    if expectZ
+      then L.runKVDB connName $ L.zrange (enc (zKeyFor "gDel")) 0 (-1)
+      else L.runKVDB connName $ L.smembers (enc (setKeyFor "gDel"))
+  -- SET delete keeps a dead tombstone at the pkey (membership lingers); ZSET delete ZREMs.
+  ok6 <-
+    check "ZSET delete removes member (SET path keeps dead-tombstone membership)" $
+      if expectZ then afterDel == Right [] else True
+
+  -- ---- 7. multi-cloud union of secondary-key resolution ------------------
+  putStrLn "\n[7] multi-cloud: secondary-key resolution unions pkeys across both clouds"
+  cleanPg
+  r7 <- runFlow $ do
+    let g = "gMC"; rowA = mkRow "mcA" g 100; rowB = mkRow "mcB" g 200
+    _ <- createWithKVConnector dbConf cfgPrimaryOnly rowA
+    _ <- createWithKVConnector dbConf cfgSecondaryAsPrimary rowB
+    res <- getPrimaryKeyFromFieldsAndValues "kvSorted" cfgMultiCloud (shouldReadZSet mode True) (keyMap @KVSorted) [("groupId", g)]
+    pure (either (const Nothing) (Just . sort) res)
+  ok7 <- check "union == {mcA, mcB} across primary+secondary" (r7 == Just (sort [pkOf (mkRow "mcA" "gMC" 100), pkOf (mkRow "mcB" "gMC" 200)]))
+
+  -- ---- 8. In on secondary key — multiple combos ⇒ fast-path falls back, union ----
+  putStrLn "\n[8] In on secondary key (groupId IN [gA,gB]) unions + orders correctly"
+  cleanPg
+  r8 <- runFlow $ do
+    forM_ [mkRow "ia1" "gA" 100, mkRow "ia2" "gA" 300, mkRow "ib1" "gB" 200] (createWithKVConnector dbConf meshCfg)
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (In (["gA", "gB"] :: [Text]))] (Desc updatedAt) (Just 10) Nothing
+  ok8 <- check "In[gA,gB] desc updatedAt == [ia2, ib1, ia1]" $ case r8 of
+    Right rows -> map id rows == ["ia2", "ib1", "ia1"]
+    Left _ -> False
+
+  -- ---- 9. residual non-indexed predicate ⇒ fast-path falls back, filter applied ----
+  putStrLn "\n[9] residual predicate (groupId=g AND payload=..) filters in memory"
+  cleanPg
+  r9 <- runFlow $ do
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "r1keep" "g9" 100) {payload = "keep"}
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "r2drop" "g9" 200) {payload = "drop"}
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("g9" :: Text)), Is payload (Eq ("keep" :: Text))] (Desc updatedAt) (Just 10) Nothing
+  ok9 <- check "residual payload filter ⇒ [r1keep]" $ case r9 of
+    Right rows -> map id rows == ["r1keep"]
+    Left _ -> False
+
+  -- ---- 10. orderBy on a non-score column ⇒ fast-path falls back, sorts by it ----
+  putStrLn "\n[10] orderBy != score column (Desc payload) falls back, sorts by payload"
+  cleanPg
+  r10 <- runFlow $ do
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "o_z" "g10" 100) {payload = "zzz"}
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "o_a" "g10" 300) {payload = "aaa"}
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("g10" :: Text))] (Desc payload) (Just 10) Nothing
+  ok10 <- check "Desc payload ⇒ [o_z, o_a]" $ case r10 of
+    Right rows -> map id rows == ["o_z", "o_a"]
+    Left _ -> False
+
+  -- ---- 11. offset + limit ----
+  putStrLn "\n[11] offset 1 limit 1 (Desc updatedAt) ⇒ second row"
+  cleanPg
+  r11 <- runFlow $ do
+    forM_ [mkRow "c1" "g11" 100, mkRow "c2" "g11" 200, mkRow "c3" "g11" 300] (createWithKVConnector dbConf meshCfg)
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("g11" :: Text))] (Desc updatedAt) (Just 1) (Just 1)
+  ok11 <- check "offset 1 limit 1 ⇒ [c2]" $ case r11 of
+    Right rows -> map id rows == ["c2"]
+    Left _ -> False
+
+  -- ---- 12. TTL-skew: a dead ZSET member (row blob gone) must not corrupt results ----
+  putStrLn "\n[12] dead ZSET member (TTL-skew) ⇒ pushdown falls back, result still correct"
+  cleanPg
+  r12 <- runFlow $ do
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "real" "g12" 100)
+    -- inject a stale member (no row blob) with a HIGH score, as a TTL-expired row would leave
+    _ <- L.runKVDB connName $ L.zadd (enc (zKeyFor "g12")) [(9.99e11, enc "kvSorted_id_ghost{shard-1}")]
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("g12" :: Text))] (Desc updatedAt) (Just 10) Nothing
+  ok12 <- check "stale member skipped ⇒ [real]" $ case r12 of
+    Right rows -> map id rows == ["real"]
+    Left _ -> False
+
+  -- ---- 13. empty result ----
+  putStrLn "\n[13] no matching rows ⇒ []"
+  cleanPg
+  r13 <- runFlow $ findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("nope" :: Text))] (Desc updatedAt) (Just 10) Nothing
+  ok13 <- check "empty ⇒ []" $ case r13 of Right [] -> True; _ -> False
+
+  -- ---- 14. In on PRIMARY key (batch get) ----
+  putStrLn "\n[14] In on primary key (id IN [..]) batch get + order"
+  cleanPg
+  r14 <- runFlow $ do
+    forM_ [mkRow "p1" "g14" 100, mkRow "p2" "g14" 200, mkRow "p3" "g14" 300] (createWithKVConnector dbConf meshCfg)
+    findAllWithOptionsKVConnector dbConf meshCfg [Is id (In (["p1", "p2", "p3"] :: [Text]))] (Desc updatedAt) (Just 10) Nothing
+  ok14 <- check "id IN [p1,p2,p3] desc ⇒ [p3,p2,p1]" $ case r14 of
+    Right rows -> map id rows == ["p3", "p2", "p1"]
+    Left _ -> False
+
+  -- ---- 15. dedup: a row present in both clouds is returned exactly once ----
+  putStrLn "\n[15] dedup — a row in BOTH clouds is returned once (multi-cloud findAllWithOptions)"
+  cleanPg
+  r15 <- runFlow $ do
+    let row = mkRow "dup1" "g15" 100
+    _ <- createWithKVConnector dbConf cfgPrimaryOnly row
+    _ <- createWithKVConnector dbConf cfgSecondaryAsPrimary row
+    findAllWithOptionsKVConnector dbConf cfgMultiCloud [Is groupId (Eq ("g15" :: Text))] (Desc updatedAt) (Just 10) Nothing
+  ok15 <- check "row in both clouds appears once" $ case r15 of
+    Right rows -> map id rows == ["dup1"]
+    Left _ -> False
+
+  -- ---- 16. range query (non-Eq/In term) ⇒ no KV key ⇒ served from Postgres ----
+  putStrLn "\n[16] range query (updatedAt > t) — no KV index key ⇒ Postgres fallback"
+  cleanPg
+  runRaw "INSERT INTO kv_sorted (id,group_id,updated_at,payload) VALUES ('rg1','gR','2026-03-01T00:00:00Z','x'),('rg2','gR','2026-03-02T00:00:00Z','y')"
+  r16 <- runFlow $ findAllWithOptionsKVConnector dbConf meshCfg [Is updatedAt (GreaterThan (UTCTime (fromGregorian 2026 2 28) (secondsToDiffTime 0)))] (Desc updatedAt) (Just 10) Nothing
+  ok16 <- check "range > t ⇒ [rg2, rg1] from DB" $ case r16 of
+    Right rows -> map id rows == ["rg2", "rg1"]
+    Left _ -> False
+
+  -- ---- 17. OR across two groups ⇒ fast-path falls back, union returned ----
+  putStrLn "\n[17] OR of two groups ⇒ fast-path falls back, union returned"
+  cleanPg
+  r17 <- runFlow $ do
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "or_a" "g17a" 100)
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "or_b" "g17b" 200)
+    findAllWithOptionsKVConnector dbConf meshCfg [Or [Is groupId (Eq ("g17a" :: Text)), Is groupId (Eq ("g17b" :: Text))]] (Desc updatedAt) (Just 10) Nothing
+  ok17 <- check "OR[g17a,g17b] ⇒ [or_b, or_a]" $ case r17 of
+    Right rows -> map id rows == ["or_b", "or_a"]
+    Left _ -> False
+
+  -- ---- 18. ZSET fast-path is OBSERVABLE: the pushdown reads the ZSET only (no
+  -- DB union), the in-mem fallback unions Postgres. A DB-only row with the highest
+  -- score therefore appears in the result ONLY when the fallback ran. So in
+  -- ZSetOnly the pushdown must EXCLUDE it; in SetOnly/DualWrite the fallback must
+  -- INCLUDE it. This makes a dead pushdown (always Nothing) detectable: it would
+  -- include the DB row in ZSetOnly and fail. ----
+  putStrLn "\n[18] ZSET fast-path is observable (pushdown is index-only; fallback unions DB)"
+  cleanPg
+  r18 <- runFlow $ do
+    -- two KV rows (go into the ZSET in ZSetOnly), scores 100 & 200
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "fp_lo" "gFP" 100)
+    _ <- createWithKVConnector dbConf meshCfg (mkRow "fp_hi" "gFP" 200)
+    -- a DB-ONLY row with the HIGHEST score (300) — present in Postgres, absent from the ZSET
+    L.runIO $ runRaw "INSERT INTO kv_sorted (id,group_id,updated_at,payload) VALUES ('fp_db','gFP','2026-01-01T00:05:00Z','db')"
+    findAllWithOptionsKVConnector dbConf meshCfg [Is groupId (Eq ("gFP" :: Text))] (Desc updatedAt) (Just 2) Nothing
+  let gotIds = case r18 of Right rows -> map id rows; Left _ -> []
+      pushdownRan = shouldReadZSet mode True -- True only in ZSetOnly for a sorted table
+      expected = if pushdownRan then ["fp_hi", "fp_lo"] else ["fp_db", "fp_hi"]
+  ok18 <-
+    check
+      ( "fast-path "
+          <> (if pushdownRan then "pushdown ⇒ DB-only high-score row EXCLUDED ⇒ [fp_hi,fp_lo]" else "fallback ⇒ DB row UNIONED ⇒ [fp_db,fp_hi]")
+      )
+      (gotIds == expected)
+
+  -- ---- 19. MIXED-VERSION SAFETY (rolling deploy / two binaries) ----
+  -- The phase now lives on MeshConfig (per-table, from shared-kernel's Tables
+  -- config), so we can prove cross-version coexistence in ONE process by reading
+  -- the same DualWrite-written row through three different configs:
+  --   * a DualWrite WRITE populates BOTH the SET and the ZSET;
+  --   * a SetOnly  reader (an OLD pod, or a not-yet-cut-over new pod) reads the SET → finds it;
+  --   * a ZSetOnly reader (a fully cut-over new pod)                 reads the ZSET → finds it.
+  -- This is the guarantee that lets an old (no-sorted-set) deployment and a new
+  -- one run side by side during the DualWrite phase without losing rows.
+  putStrLn "\n[19] mixed-version: a DualWrite-written row is found by BOTH a SET reader and a ZSET reader"
+  cleanPg
+  let cfgDual = meshCfg {sortedIndexMode = DualWrite}
+      cfgSet = meshCfg {sortedIndexMode = SetOnly}
+      cfgZ = meshCfg {sortedIndexMode = ZSetOnly}
+  (viaSet, viaZ) <- runFlow $ do
+    flushTestKeys
+    _ <- createWithKVConnector dbConf cfgDual (mkRow "mv_a" "gMV" 100) -- writes SET + ZSET
+    _ <- createWithKVConnector dbConf cfgDual (mkRow "mv_b" "gMV" 200)
+    a <- findAllWithOptionsKVConnector dbConf cfgSet [Is groupId (Eq ("gMV" :: Text))] (Desc updatedAt) (Just 10) Nothing
+    b <- findAllWithOptionsKVConnector dbConf cfgZ [Is groupId (Eq ("gMV" :: Text))] (Desc updatedAt) (Just 10) Nothing
+    pure (a, b)
+  ok19a <- check "old/SET reader sees DualWrite rows ⇒ [mv_b, mv_a]" $ case viaSet of Right rs -> map id rs == ["mv_b", "mv_a"]; Left _ -> False
+  ok19b <- check "new/ZSET reader sees DualWrite rows ⇒ [mv_b, mv_a]" $ case viaZ of Right rs -> map id rs == ["mv_b", "mv_a"]; Left _ -> False
+
+  cleanPg
+  let results = [ok1, ok2a, ok2b, ok3, ok4, ok5a, ok5b, ok6, ok7, ok8, ok9, ok10, ok11, ok12, ok13, ok14, ok15, ok16, ok17, ok18, ok19a, ok19b]
+      passed = length (filter (== True) results)
+  putStrLn $ "\n=== [phase=" <> show mode <> "] " <> show passed <> "/" <> show (length results) <> " passed ==="
+  pure (and results)

--- a/test/suite/Main.hs
+++ b/test/suite/Main.hs
@@ -12,9 +12,9 @@
 --
 -- What it runs (with per-suite logs + a final PASS/FAIL summary):
 --   • kv-live              — every EulerHS.KVConnector.Flow function, live PG+Redis
---   • encoding/compression — value codec round-trips
---   • recache flags        — IS_CACHING_DB_FIND_ENABLED / IS_RECACHING_ENABLED
---   • jsonb-live           — jsonb fallback (skips if the atlas DB is absent)
+--   • sorted-set-live      — ZSET sorted-secondary-index incl. zadd/zrange/zrem
+--                            parsing, across all 3 rollout phases (SetOnly /
+--                            DualWrite / ZSetOnly) as child processes
 --   • db                   — SQLite query-builder + pgexercises clubdata (hspec)
 --   • extra                — aeson option deriving (hspec)
 --
@@ -24,7 +24,7 @@
 module Main (main) where
 
 import Control.Exception (SomeException, try)
-import Control.Monad (unless, void)
+import Control.Monad (forM, unless, void)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Database.PostgreSQL.Simple as PGS
@@ -38,6 +38,7 @@ import KvLiveTests (runKvLiveTests, runRecacheTests)
 import qualified Options
 import qualified SQLDB.Tests.QueryExamplesSpec as QueryExamples
 import qualified SQLDB.Tests.SQLiteDBSpec as SQLiteDB
+import SortedSetTests (runSortedSetTests)
 import System.Environment (getArgs, getEnvironment, getExecutablePath)
 import System.Exit (ExitCode (..), exitFailure, exitSuccess, exitWith)
 import System.IO (BufferMode (..), hSetBuffering, stdout)
@@ -50,6 +51,12 @@ main = do
   hSetBuffering stdout LineBuffering
   args <- getArgs
   case args of
+    -- Child invocation: run ONLY the sorted-set suite for the phase in
+    -- KV_SORTED_INDEX_MODE (the mode is read once per process, so each phase
+    -- needs its own process).
+    ("--sorted-phase" : _) -> do
+      ok <- runSortedSetTests
+      exitWith (if ok then ExitSuccess else ExitFailure 1)
     -- Child: recache flags are per-process CAFs, set in this child's env.
     ("--recache-phase" : _) -> do
       ok <- runRecacheTests
@@ -81,8 +88,16 @@ orchestrate = do
   -- 1b) value codec: JSON/CBOR/DEAD headers + zstd compression -------------
   encOk <- runEncodingTests
 
+  -- 2) Sorted-set across all 3 rollout phases (child processes) ------------
   self <- getExecutablePath
   baseEnv <- getEnvironment
+  sortedOks <- forM phases $ \(label, modeEnv) -> do
+    putStrLn $ "\n>>> launching sorted-set-live phase: " <> label
+    let env' = ("KV_SORTED_INDEX_MODE", modeEnv) : filter ((/= "KV_SORTED_INDEX_MODE") . fst) baseEnv
+    (_, _, _, ph) <-
+      createProcess (proc self ["--sorted-phase"]) {env = Just env', std_out = Inherit, std_err = Inherit}
+    code <- waitForProcess ph
+    pure ("sorted-set-live [" <> label <> "]", code == ExitSuccess)
 
   -- 2b) Recache flags in a child process (CAF env: caching-db-find + recaching) --
   putStrLn "\n>>> launching recache-flags phase (IS_CACHING_DB_FIND_ENABLED + IS_RECACHING_ENABLED)"
@@ -119,6 +134,7 @@ orchestrate = do
         [ ("kv-live (full KV connector surface)", kvOk),
           ("encoding + compression (JSON/CBOR/DEAD/zstd)", encOk)
         ]
+          <> sortedOks
           <> [ ("recache flags (caching-db-find + recaching)", recacheOk),
                ("jsonb-live (skipped if atlas DB absent)", jsonbOk),
                ("extra (hspec)", summaryFailures exSum == 0),
@@ -131,6 +147,8 @@ orchestrate = do
   if all snd rows
     then putStrLn "\n✅ ALL TESTS GREEN" >> exitSuccess
     else putStrLn "\n❌ FAILURES ABOVE — see logs" >> exitFailure
+  where
+    phases = [("SetOnly", ""), ("DualWrite", "DUAL"), ("ZSetOnly", "ZSET_ONLY")]
 
 -- =============================================================================
 -- Preflight: fail fast with actionable instructions if infra is down.


### PR DESCRIPTION
Sorted-secondary-index support: maintain a Redis **ZSET** alongside the plain SET so `findAllWithOptions` can push `LIMIT`/`OFFSET` (ordered by a time/score column) into Redis via `zrevrangebyscorewithlimit`, instead of fetching all members and sorting in memory.

### Rollout switch is per-table, from config (not a global env)
The phase lives on `MeshConfig.sortedIndexMode` ∈ `SetOnly | DualWrite | ZSetOnly`, set per-table in **shared-kernel** from the `Tables` config (`kvTablesSortedIndexMode`, a `Map Text Text` in kv_configs) — flip a table's phase centrally, no redeploy. `shouldWriteSet/ZSet/ReadZSet` take the phase explicitly; `defaultSortedIndexMode` remains as the legacy `KV_SORTED_INDEX_MODE` env fallback.

> Companion change (separate PR): `shared-kernel` `Kernel.Types.Common.Tables` gains `kvTablesSortedIndexMode`, and `Kernel.Beam.Functions.setMeshConfig` populates `MeshConfig.sortedIndexMode` from it. Requires bumping shared-kernel's euler-hs pin to this commit.

### Backward / mixed-version safety
- Non-sorted tables ignore the phase entirely (behaviour identical to before).
- `SetOnly` (default) writes/reads only the SET — byte-for-byte the old behaviour.
- `DualWrite` writes **both** SET and ZSET while reading the SET, so an **old SET-only binary and a new binary coexist** during a rolling deploy without losing rows. `ZSetOnly` is entered only after every pod is upgraded.
- nammayatri backend constructs `MeshConfig` nowhere (uses the wrappers), and old binaries ignore the new config field (aeson drops unknown keys) — so adding the field breaks nothing.

### Tests
`cabal test` → **9/9 green**, including sorted-set-live's **21 assertions × 3 phases**: ZSET primitives, create/update/delete index maintenance, the fast-path-vs-fallback observability check, multi-cloud union/dedup, and a new **mixed-version test** proving a `DualWrite`-written row is found by *both* a SET reader and a ZSET reader.

Library diff only touches the KV connector; sits on top of the test-harness branch (#61, merged).