### PR TITLE
KV/Enh: Per-table recache-on-find flag (MeshConfig.recacheFindEnabled)

### DIFF
--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -958,7 +958,7 @@ findWithKVConnector dbConf meshCfg whereClause = do
               case res of
                 Right (Just dbRow) -> do
                   Metrics.incrementKVHitMissMetric "FIND" modelName Metrics.KVMissDBHit
-                  if isCachingDbFindEnabled && meshCfg.meshEnabled
+                  if (isCachingDbFindEnabled || meshCfg.recacheFindEnabled) && meshCfg.meshEnabled
                     then do
                       reCacheDBRowsRes <- createInRedis meshCfg dbRow
                       case reCacheDBRowsRes of

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -114,7 +114,8 @@ data MeshConfig = MeshConfig
     kvHardKilled :: Bool,
     tableShardModRange :: (Int, Int),
     redisKeyPrefix :: Text,
-    forceDrainToDB :: Bool
+    forceDrainToDB :: Bool,
+    recacheFindEnabled :: Bool
   }
   deriving (Generic, Eq, Show, A.ToJSON)
 

--- a/test/kv-live/KvLiveTests.hs
+++ b/test/kv-live/KvLiveTests.hs
@@ -111,7 +111,8 @@ meshCfg =
       kvHardKilled = False,
       tableShardModRange = (0, 128),
       redisKeyPrefix = "",
-      forceDrainToDB = False
+      forceDrainToDB = False,
+      recacheFindEnabled = False
     }
 
 -- Treat the secondary Redis as this pod's primary (used to seed the "other cloud").

--- a/test/language/KV/TestSchema/Mesh.hs
+++ b/test/language/KV/TestSchema/Mesh.hs
@@ -26,7 +26,8 @@ meshConfig =
       kvHardKilled = False,
       tableShardModRange = (0, 128),
       redisKeyPrefix = "",
-      forceDrainToDB = False
+      forceDrainToDB = False,
+      recacheFindEnabled = False
     }
 
 dbMeshTrackerTables :: Set.Set Text


### PR DESCRIPTION
## What

Adds a per-table opt-in for recaching a DB row back into Redis on a KV miss in the **single-row find path** (`findWithKVConnector`).

New field `MeshConfig.recacheFindEnabled :: Bool`. The recache now fires when **either**:
- the global env flag `IS_CACHING_DB_FIND_ENABLED` is on, **or**
- the per-table `recacheFindEnabled` is set.

```haskell
if (isCachingDbFindEnabled || meshCfg.recacheFindEnabled) && meshCfg.meshEnabled
  then reCache dbRow into pod-local Redis (createInRedis)
  else return DB row without caching
```

## Scope

- **findOne only** — `findWithKVConnector`. `findAll` / update paths are unchanged.
- Recache target is **pod-local** (`meshCfg.kvRedis`), same as the existing env-flag behavior — no cross-cloud reconciliation change.

## Safety

- Defaults to `False` in every construction → **behavior is byte-identical to today** until a table opts in.
- Library builds clean under `-Wall -Werror`.

## Required follow-up (shared-kernel — separate repo)

`MeshConfig` is constructed in `shared-kernel/lib/mobility-core/src/Kernel/Beam/Functions.hs` (`setMeshConfig` / `setMeshConfigForFindAll`). `recacheFindEnabled` must be added there (populated from `kv_configs`, mirroring `secondaryRedisEnabled`) **before that repo will compile**.

## Test plan

- [x] `cabal build lib:euler-hs` — passes (`-Werror`)
- [ ] `cabal run test:tests -- --recache-phase` (needs local PG+Redis)
- [ ] Add a kv-live case asserting `recacheFindEnabled=True` with env flag **off** recaches on DB miss (follow-up)