### PR TITLE
fix: partial (pinned) secondary keys must not poison key-set intersec…

### DIFF
--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -1098,7 +1098,7 @@ findOneFromRedis meshCfg whereClause = do
       clusterName = if meshCfg.kvRedis == meshCfg.kvRedisSecondary then "secondaryCluster" else "primaryCluster"
 
   Metrics.withKVLatencyMetric "REDIS_FIND_ONE" modelName clusterName $ do
-    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinationsFiltered
+    eitherKeyRes <- mapM (\combo -> getPrimaryKeyFromFieldsAndValues modelName meshCfg (validKeyMapForClause (pinnedKeyMap @(table Identity)) keyHashMap combo) combo) andCombinationsFiltered
     result <- case foldEither eitherKeyRes of
       Right keyRes -> do
         let lenKeyRes = lengthOfLists keyRes
@@ -1645,7 +1645,7 @@ redisFindAll meshCfg whereClause = do
       clusterName = if meshCfg.kvRedis == meshCfg.kvRedisSecondary then "secondaryCluster" else "primaryCluster"
 
   Metrics.withKVLatencyMetric "REDIS_FIND_ALL" modelName clusterName $ do
-    eitherKeyRes <- mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinationsFiltered
+    eitherKeyRes <- mapM (\combo -> getPrimaryKeyFromFieldsAndValues modelName meshCfg (validKeyMapForClause (pinnedKeyMap @(table Identity)) keyHashMap combo) combo) andCombinationsFiltered
     result <- case foldEither eitherKeyRes of
       Right keyRes -> do
         let allKeys = concat keyRes

--- a/src/EulerHS/KVConnector/InMemConfig/Flow.hs
+++ b/src/EulerHS/KVConnector/InMemConfig/Flow.hs
@@ -307,7 +307,7 @@ searchInMemoryCache meshCfg dbConf whereClause = do
           keyHashMap = keyMap @(table Identity)
       eitherKeyRes <-
         if fetchFromRedis
-          then mapM (getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap) andCombinations
+          then mapM (\combo -> getPrimaryKeyFromFieldsAndValues modelName meshCfg (validKeyMapForClause (pinnedKeyMap @(table Identity)) keyHashMap combo) combo) andCombinations
           else mapM (getPrimaryKeyInIMCFromFieldsAndValues modelName keyHashMap) andCombinations
       pure $ foldEither eitherKeyRes
 

--- a/src/EulerHS/KVConnector/Types.hs
+++ b/src/EulerHS/KVConnector/Types.hs
@@ -46,6 +46,8 @@ data SecondaryKey = SKey [(Text, Text)]
 class KVConnector table where
   tableName :: Text
   keyMap :: HM.HashMap Text Bool -- True implies it is primary key and False implies secondary
+  pinnedKeyMap :: HM.HashMap Text [Text]
+  pinnedKeyMap = HM.empty
   primaryKey :: table -> PrimaryKey
   secondaryKeys :: table -> [SecondaryKey]
   mkSQLObject :: table -> A.Value

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -672,6 +672,22 @@ getFieldsAndValuesFromClause dt = \case
       A.Bool b -> T.pack $ show b
       A.Null -> T.pack ""
 
+-- | The keyMap a given where-clause combination is allowed to use. A pinned (partial) key set is
+--   written only for its pinned values, so an empty SMEMBERS on it is not evidence of "no rows"
+--   and must never participate in the key-set intersection of 'getPrimaryKeyFromFieldsAndValues'.
+--   Pinned fields are therefore a fallback only: if the clause has any regular (non-pinned) key,
+--   all pinned fields are removed from the map; otherwise only pinned fields whose queried value
+--   is actually pinned survive. Removed fields still apply later via in-app row matching.
+validKeyMapForClause :: HM.HashMap Text [Text] -> HM.HashMap Text Bool -> [(Text, Text)] -> HM.HashMap Text Bool
+validKeyMapForClause pinnedKeyHashMap keyHashMap fieldsAndValues
+  | HM.null pinnedKeyHashMap = keyHashMap
+  | hasRegularKey = foldr HM.delete keyHashMap (HM.keys pinnedKeyHashMap)
+  | otherwise = foldr HM.delete keyHashMap uncoveredPinnedFields
+  where
+    isPinned k = HM.member k pinnedKeyHashMap
+    hasRegularKey = any (\(k, _) -> HM.member k keyHashMap && not (isPinned k)) fieldsAndValues
+    uncoveredPinnedFields = [k | (k, v) <- fieldsAndValues, maybe False (v `notElem`) (HM.lookup k pinnedKeyHashMap)]
+
 getPrimaryKeyFromFieldsAndValues :: (L.MonadFlow m) => Text -> MeshConfig -> HM.HashMap Text Bool -> [(Text, Text)] -> m (MeshResult [ByteString])
 getPrimaryKeyFromFieldsAndValues _ _ _ [] = pure $ Right []
 getPrimaryKeyFromFieldsAndValues modelName meshCfg keyHashMap fieldsAndValues = do


### PR DESCRIPTION
…tion

Pinned key sets are only written for their pinned values, so an empty SMEMBERS on them is not evidence of no rows. validKeyMapForClause now computes the keyMap a where-clause combination may use: pinned fields are dropped whenever a regular key is present, and used only when they are the sole keys in the clause with a pinned value. Pin metadata comes from the new KVConnector.pinnedKeyMap method (defaulted to empty, fully backward compatible).